### PR TITLE
chore(create-stark-rn): migrate template to @starknet-start/* + modern Contract ctor

### DIFF
--- a/packages/create-stark-rn/template/rn/app/(tabs)/settings.tsx
+++ b/packages/create-stark-rn/template/rn/app/(tabs)/settings.tsx
@@ -1,11 +1,13 @@
 import { ConnectedWalletMenu } from "@/app/_components/ConnectedWalletMenu";
 import { WelcomeSection } from "@/app/_components/WelcomeSection";
-import { useAccount } from "@starknet-react/core";
+import { useWalletModal } from "@/app/_layout";
+import { useAccount } from "@starknet-start/react";
 import React from "react";
 import { ScrollView, StatusBar, View } from "react-native";
 
 export default function Settings() {
   const { address } = useAccount();
+  const { openConnectModal } = useWalletModal();
 
   return (
     <View className="flex-1">
@@ -18,8 +20,8 @@ export default function Settings() {
         showsVerticalScrollIndicator={false}
         contentContainerStyle={{ flexGrow: 1 }}
       >
-        {address && <WelcomeSection address={address} />}
-        <ConnectedWalletMenu address={address} />
+        <WelcomeSection address={address} />
+        <ConnectedWalletMenu address={address} onConnectWallet={openConnectModal} />
       </ScrollView>
     </View>
   );

--- a/packages/create-stark-rn/template/rn/app/_components/ConnectedWalletMenu.tsx
+++ b/packages/create-stark-rn/template/rn/app/_components/ConnectedWalletMenu.tsx
@@ -1,6 +1,5 @@
 import Ionicons from "@expo/vector-icons/Ionicons";
-import { useDisconnect } from "@starknet-react/core";
-import { LinearGradient } from "expo-linear-gradient";
+import { useDisconnect } from "@starknet-start/react";
 import React from "react";
 import { Text, TouchableOpacity, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -11,144 +10,97 @@ import {
 
 interface ConnectedWalletMenuProps {
   address?: string;
+  onConnectWallet?: () => void;
 }
 
-export function ConnectedWalletMenu({ address }: ConnectedWalletMenuProps) {
+export function ConnectedWalletMenu({ address, onConnectWallet }: ConnectedWalletMenuProps) {
   const { theme, isDark } = useTheme();
   const colors = themeColors[theme];
   const insets = useSafeAreaInsets();
 
   const { disconnect } = useDisconnect();
 
-  const menuItems = [
-    {
-      icon: "search-outline",
-      title: "Block Explorer",
-      status: "Coming soon",
-      onPress: () => {},
-    },
-    {
-      icon: "settings-outline",
-      title: "Configure Contracts",
-      status: "Coming soon",
-      onPress: () => {},
-    },
-    {
-      icon: "cash-outline",
-      title: "Faucet",
-      status: "Coming soon",
-      onPress: () => {},
-    },
-  ];
-
   return (
     <View
-      className="flex-1 px-4"
+      className="px-4"
       style={{
         marginBottom: insets.bottom + 72,
       }}
     >
-      {/* Main Container with #000000B8 background */}
       <View
-        className="rounded-2xl p-4 flex-1 flex-col gap-1 justify-between"
+        className="rounded-2xl p-4"
         style={{
           backgroundColor: isDark ? "#000000B8" : "#FFFFFFB8",
         }}
       >
-        <View>
-          {/* Menu Items */}
-          {menuItems.map((item, index) => (
-            <TouchableOpacity
-              key={index}
-              onPress={item.onPress}
-              className="mb-3"
-              style={{
-                shadowColor: "#000",
-                shadowOffset: { width: 0, height: 4 },
-                shadowOpacity: 0.1,
-                shadowRadius: 6,
-                elevation: 4,
-              }}
-            >
-              <LinearGradient
-                colors={
-                  isDark ? ["#2A3655", "#5C92BB"] : ["#FFFFFF", "#FFFFFF"]
-                }
-                start={{ x: 0, y: 0 }}
-                end={{ x: 1, y: 0 }}
+        {!address && (
+          <>
+            <View className="flex-row items-center mb-3 px-1">
+              <Ionicons
+                name="warning-outline"
+                size={16}
+                color={isDark ? "#FBBF24" : "#D97706"}
+                style={{ marginRight: 6 }}
+              />
+              <Text
+                className="text-sm"
+                style={{ color: isDark ? "#FBBF24" : "#D97706" }}
+              >
+                Connect a wallet to send transactions
+              </Text>
+            </View>
+            {onConnectWallet && (
+              <TouchableOpacity
+                onPress={onConnectWallet}
+                className="flex-row items-center justify-center px-3 py-2.5 rounded-full"
                 style={{
-                  flexDirection: "row",
-                  alignItems: "center",
-                  paddingVertical: 10,
-                  paddingHorizontal: 12,
-                  borderRadius: 9999,
-                  borderWidth: isDark ? 1 : 0,
-                  borderColor: isDark ? "#696969" : "#FFFFFF",
-                  borderStyle: "solid",
+                  backgroundColor: colors.primary,
+                  shadowColor: "#000",
+                  shadowOffset: { width: 0, height: 4 },
+                  shadowOpacity: 0.1,
+                  shadowRadius: 6,
+                  elevation: 4,
                 }}
               >
-                <View className="w-[18px] h-[18px] items-center justify-center mr-1">
-                  <Ionicons
-                    name={item.icon as any}
-                    size={16}
-                    color={isDark ? "white" : "#747474"}
-                  />
-                </View>
-                <View className="flex-1">
-                  <Text style={{ color: colors.text }}>{item.title}</Text>
-                </View>
-                <Text
-                  className="italic font-medium"
-                  style={{ color: isDark ? "#A7ECFF" : "#656565" }}
-                >
-                  <Text style={{ color: "#4DB4FF" }}>[</Text>
-                  <Text>{item.status}</Text>
-                  <Text style={{ color: "#4DB4FF" }}>]</Text>
+                <Ionicons
+                  name="wallet-outline"
+                  size={20}
+                  color="white"
+                  style={{ marginRight: 4 }}
+                />
+                <Text className="text-white font-medium text-base">
+                  Connect Wallet
                 </Text>
-              </LinearGradient>
-            </TouchableOpacity>
-          ))}
-        </View>
+              </TouchableOpacity>
+            )}
+          </>
+        )}
 
-        {/* Disconnect Button */}
         {address && (
-          <View
+          <TouchableOpacity
+            onPress={() => {
+              disconnect();
+            }}
+            className="flex-row items-center justify-center px-3 py-2.5 rounded-full"
             style={{
-              // Second, softer shadow layer: 0 2px 4px -2px rgba(0,0,0,0.10)
+              backgroundColor: "#FF0000",
               shadowColor: "#000",
-              shadowOffset: { width: 0, height: 2 },
+              shadowOffset: { width: 0, height: 4 },
               shadowOpacity: 0.1,
-              shadowRadius: 4,
-              elevation: 2,
-              borderRadius: 9999,
+              shadowRadius: 6,
+              elevation: 4,
             }}
           >
-            <TouchableOpacity
-              onPress={() => {
-                disconnect();
-              }}
-              className="flex-row items-center justify-center px-3 py-2.5 rounded-full"
-              style={{
-                backgroundColor: "#FF0000",
-                // Primary shadow layer: 0 4px 6px -1px rgba(0,0,0,0.10)
-                shadowColor: "#000",
-                shadowOffset: { width: 0, height: 4 },
-                shadowOpacity: 0.1,
-                shadowRadius: 6,
-                elevation: 4,
-              }}
-            >
-              <Ionicons
-                name="log-out-outline"
-                size={20}
-                color="white"
-                style={{ marginRight: 4, transform: [{ scaleX: -1 }] }}
-              />
-              <Text className="text-white font-medium text-base">
-                Disconnect Wallet
-              </Text>
-            </TouchableOpacity>
-          </View>
+            <Ionicons
+              name="log-out-outline"
+              size={20}
+              color="white"
+              style={{ marginRight: 4, transform: [{ scaleX: -1 }] }}
+            />
+            <Text className="text-white font-medium text-base">
+              Disconnect Wallet
+            </Text>
+          </TouchableOpacity>
         )}
       </View>
     </View>

--- a/packages/create-stark-rn/template/rn/app/_components/debug/contract/ContractInput.tsx
+++ b/packages/create-stark-rn/template/rn/app/_components/debug/contract/ContractInput.tsx
@@ -18,10 +18,8 @@ import {
   isCairoVoid,
 } from "@/utils/scaffold-stark/typeValidations";
 import { Abi } from "abi-wan-kanabi";
-import { Dispatch, SetStateAction } from "react";
+import React, { Dispatch, SetStateAction } from "react";
 import { Text, View } from "react-native";
-import ArrayInput from "./Array";
-import Struct from "./Struct";
 import {
   addError,
   clearError,
@@ -66,6 +64,10 @@ export const ContractInput = ({
   };
 
   const renderInput = () => {
+    // Lazy require to break circular dependency (ContractInput -> Array/Struct -> ContractInput)
+    const ArrayInput = require("./Array").default;
+    const Struct = require("./Struct").default;
+
     if (isCairoArray(paramType.type)) {
       return (
         <ArrayInput

--- a/packages/create-stark-rn/template/rn/app/_components/debug/contract/DisplayVariable.tsx
+++ b/packages/create-stark-rn/template/rn/app/_components/debug/contract/DisplayVariable.tsx
@@ -4,8 +4,8 @@ import {
 } from "@/components/scaffold-stark/ThemeProvider";
 import { AbiFunction } from "@/utils/scaffold-stark/contract";
 import { EvilIcons } from "@expo/vector-icons";
-import { Address } from "@starknet-react/chains";
-import { useReadContract } from "@starknet-react/core";
+import { Address } from "@starknet-start/chains";
+import { useReadContract } from "@starknet-start/react";
 import { Abi } from "abi-wan-kanabi";
 import { useEffect } from "react";
 import { ActivityIndicator, Text, TouchableOpacity, View } from "react-native";

--- a/packages/create-stark-rn/template/rn/app/_components/debug/contract/ReadOnlyFunctionForm.tsx
+++ b/packages/create-stark-rn/template/rn/app/_components/debug/contract/ReadOnlyFunctionForm.tsx
@@ -6,8 +6,8 @@ import {
 } from "@/components/scaffold-stark/ThemeProvider";
 import { isValidContractArgs } from "@/utils/scaffold-stark/common";
 import { AbiFunction } from "@/utils/scaffold-stark/contract";
-import { Address } from "@starknet-react/chains";
-import { useContract, useReadContract } from "@starknet-react/core";
+import { Address } from "@starknet-start/chains";
+import { useContract, useReadContract } from "@starknet-start/react";
 import { Abi } from "abi-wan-kanabi";
 import { useEffect, useRef, useState } from "react";
 import { Text, TouchableOpacity, View } from "react-native";

--- a/packages/create-stark-rn/template/rn/app/_components/debug/contract/WriteOnlyFunctionForm.tsx
+++ b/packages/create-stark-rn/template/rn/app/_components/debug/contract/WriteOnlyFunctionForm.tsx
@@ -7,8 +7,8 @@ import {
 import { useTargetNetwork } from "@/hooks/scaffold-stark/useTargetNetwork";
 import { useTransactor } from "@/hooks/scaffold-stark/useTransactor";
 import { AbiFunction } from "@/utils/scaffold-stark/contract";
-import { Address } from "@starknet-react/chains";
-import { useAccount, useContract, useNetwork } from "@starknet-react/core";
+import { Address } from "@starknet-start/chains";
+import { useAccount, useContract, useNetwork } from "@starknet-start/react";
 import { Abi } from "abi-wan-kanabi";
 import { useEffect, useMemo, useState } from "react";
 import { ActivityIndicator, Text, TouchableOpacity, View } from "react-native";
@@ -48,7 +48,7 @@ export const WriteOnlyFunctionForm = ({
   );
   const [formErrorMessage, setFormErrorMessage] =
     useState<FormErrorMessageState>({});
-  const { status: walletStatus, isConnected, account, chainId } = useAccount();
+  const { status: walletStatus, isConnected, chainId } = useAccount();
   const { chain } = useNetwork();
   const {
     writeTransaction,

--- a/packages/create-stark-rn/template/rn/app/_components/debug/contract/utilsContract.tsx
+++ b/packages/create-stark-rn/template/rn/app/_components/debug/contract/utilsContract.tsx
@@ -224,24 +224,17 @@ export const getArgsAsStringInputFromForm = (form: Record<string, any>) => {
     // translate boolean input
     if (isCairoBool(key)) return convertStringInputToBool(value);
 
-    if (
-      isValidHexNumber(value) &&
-      (isCairoBigInt(key) ||
-        isCairoInt(key) ||
-        isCairoFelt(key) ||
-        isCairoU256(key))
-    ) {
-      return num.toBigInt(value);
-    }
+    const isNumericType =
+      isCairoBigInt(key) || isCairoInt(key) || isCairoFelt(key) || isCairoU256(key);
 
-    if (
-      isValidNumber(value) &&
-      (isCairoBigInt(key) ||
-        isCairoInt(key) ||
-        isCairoFelt(key) ||
-        isCairoU256(key))
-    ) {
-      return num.toBigInt(value);
+    if (isNumericType) {
+      // Empty or whitespace-only strings default to 0n for numeric types
+      if (typeof value === "string" && value.trim() === "") {
+        return 0n;
+      }
+      if (isValidHexNumber(value) || isValidNumber(value)) {
+        return num.toBigInt(value);
+      }
     }
 
     return value;

--- a/packages/create-stark-rn/template/rn/app/_layout.tsx
+++ b/packages/create-stark-rn/template/rn/app/_layout.tsx
@@ -10,11 +10,19 @@ import * as SplashScreen from "expo-splash-screen";
 import { Header } from "@/app/_components/Header";
 import { ScaffoldBgGradient } from "@/components/scaffold-stark/gradients/ScaffoldBgGradient";
 import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
-import { useAccount } from "@starknet-react/core";
-import { useEffect, useRef } from "react";
+import { useAccount } from "@starknet-start/react";
+import { createContext, useContext, useEffect, useRef } from "react";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { WalletConnectModal } from "../components/scaffold-stark/WalletConnect/WalletConnectModal";
 import "../global.css";
+
+const WalletModalContext = createContext<{ openConnectModal: () => void }>({
+  openConnectModal: () => {},
+});
+
+export function useWalletModal() {
+  return useContext(WalletModalContext);
+}
 
 SplashScreen.preventAutoHideAsync();
 
@@ -64,14 +72,16 @@ function AppShell({ children }: { children: React.ReactNode }) {
   };
 
   return (
-    <ScaffoldBgGradient>
-      <Header
-        onConnectWallet={handleConnectWallet}
-        isWalletConnected={!!address}
-        walletAddress={address}
-      />
-      <WalletConnectModal sheetRef={walletSheetRef} onClose={() => {}} />
-      {children}
-    </ScaffoldBgGradient>
+    <WalletModalContext.Provider value={{ openConnectModal: handleConnectWallet }}>
+      <ScaffoldBgGradient>
+        <Header
+          onConnectWallet={handleConnectWallet}
+          isWalletConnected={!!address}
+          walletAddress={address}
+        />
+        <WalletConnectModal sheetRef={walletSheetRef} onClose={() => {}} />
+        {children}
+      </ScaffoldBgGradient>
+    </WalletModalContext.Provider>
   );
 }

--- a/packages/create-stark-rn/template/rn/components/scaffold-stark/Input/AddressInput.tsx
+++ b/packages/create-stark-rn/template/rn/components/scaffold-stark/Input/AddressInput.tsx
@@ -1,4 +1,4 @@
-import { Address } from "@starknet-react/chains";
+import { Address } from "@starknet-start/chains";
 import { blo } from "blo";
 import { useCallback, useEffect, useState } from "react";
 import { Image, View } from "react-native";

--- a/packages/create-stark-rn/template/rn/components/scaffold-stark/ScaffoldStarkAppWithProviders.tsx
+++ b/packages/create-stark-rn/template/rn/components/scaffold-stark/ScaffoldStarkAppWithProviders.tsx
@@ -1,6 +1,7 @@
 import { appChains, connectors } from "@/configs/connectors";
 import provider from "@/configs/provider";
-import { StarknetConfig, voyager } from "@starknet-react/core";
+import { StarknetConfig } from "@starknet-start/react";
+import { voyager } from "@starknet-start/explorers";
 import { ThemeProvider } from "./ThemeProvider";
 import { AegisProvider } from "@cavos/aegis";
 import aegisConfig from "@/configs/aegisConfig";
@@ -15,7 +16,7 @@ export function ScaffoldStarkAppWithProviders({
       <StarknetConfig
         chains={appChains}
         provider={provider}
-        connectors={connectors}
+        extraWallets={connectors}
         explorer={voyager}
       >
         <AegisProvider config={aegisConfig}>{children}</AegisProvider>

--- a/packages/create-stark-rn/template/rn/components/scaffold-stark/WalletConnect/WalletConnectModal.tsx
+++ b/packages/create-stark-rn/template/rn/components/scaffold-stark/WalletConnect/WalletConnectModal.tsx
@@ -6,13 +6,14 @@ import {
   BottomSheetModal,
   BottomSheetView,
 } from "@gorhom/bottom-sheet";
-import { burnerAccounts, BurnerConnector } from "@scaffold-stark/stark-burner";
+import { burnerAccounts, burnerWalletId } from "@scaffold-stark/stark-burner";
 import {
-  Connector,
+  MockWallet,
   useAccount,
   useConnect,
   useDisconnect,
-} from "@starknet-react/core";
+} from "@starknet-start/react";
+import type { WalletWithStarknetFeatures } from "@starknet-io/get-starknet-wallet-standard/features";
 import * as Clipboard from "expo-clipboard";
 import React, { useMemo, useState } from "react";
 import { Dimensions, Text, TouchableOpacity, View } from "react-native";
@@ -23,6 +24,11 @@ import { themeColors, useTheme } from "../ThemeProvider";
 import { CopyIcon } from "../icons/CopyIcon";
 import { ConnectorRow } from "./ConnectorRow";
 import { RNIcon } from "./RNIcon";
+
+/** Get the wallet standard ID from a WalletWithStarknetFeatures instance. */
+function getWalletId(wallet: WalletWithStarknetFeatures): string {
+  return wallet.features["starknet:walletApi"].id;
+}
 
 interface WalletConnectModalProps {
   sheetRef: React.RefObject<BottomSheetModal>;
@@ -53,8 +59,8 @@ export function WalletConnectModal({
   const isDevnet = targetNetwork.network === "devnet";
 
   const { mainConnectors, otherConnectors } = useMemo(() => {
-    const burnerConn = connectors.filter((c) => c.id === "burner-wallet");
-    const others = connectors.filter((c) => c.id !== "burner-wallet");
+    const burnerConn = connectors.filter((c) => getWalletId(c) === burnerWalletId);
+    const others = connectors.filter((c) => getWalletId(c) !== burnerWalletId);
 
     if (!isDevnet) {
       return {
@@ -69,8 +75,8 @@ export function WalletConnectModal({
     };
   }, [connectors, isDevnet]);
 
-  const handleConnectWallet = (connector: Connector) => {
-    if (connector.id === "burner-wallet") {
+  const handleConnectWallet = (connector: WalletWithStarknetFeatures) => {
+    if (getWalletId(connector) === burnerWalletId) {
       setIsBurnerWallet(true);
       return;
     }
@@ -78,7 +84,7 @@ export function WalletConnectModal({
     try {
       connect({ connector });
     } catch (error) {
-      if (connector.id === "ready-mobile") {
+      if (getWalletId(connector) === "ready-mobile") {
         appToast.showPersistentInfo(
           "Connecting to Ready...",
           "If Ready doesn't open, install it and try again.",
@@ -92,10 +98,12 @@ export function WalletConnectModal({
   };
 
   const handleConnectBurner = (ix: number) => {
-    const connector = connectors.find((it) => it.id === "burner-wallet");
-    if (connector && connector instanceof BurnerConnector) {
-      connector.burnerAccount = burnerAccounts[ix];
-      connect({ connector });
+    const wallet = connectors.find(
+      (it) => getWalletId(it) === burnerWalletId,
+    );
+    if (wallet && wallet instanceof MockWallet) {
+      wallet.switchAccount(ix);
+      connect({ connector: wallet });
       onClose && onClose();
     }
   };
@@ -254,19 +262,19 @@ export function WalletConnectModal({
                   <>
                     {mainConnectors.map((connector) => (
                       <View
-                        key={connector.id || connector.name}
+                        key={getWalletId(connector) || connector.name}
                         style={{ marginTop: 6 }}
                       >
                         <ConnectorRow
                           title={connector.name}
                           iconUri={(connector.icon as any)[theme]}
                           iconBg={
-                            connector.id === "burner-wallet"
+                            getWalletId(connector) === burnerWalletId
                               ? "#3B82F6"
                               : "#FFFFFF"
                           }
                           iconColor={
-                            connector.id === "burner-wallet"
+                            getWalletId(connector) === burnerWalletId
                               ? "#FFFFFF"
                               : "#F97316"
                           }
@@ -294,7 +302,7 @@ export function WalletConnectModal({
                   <>
                     {otherConnectors.map((connector) => (
                       <View
-                        key={connector.id || connector.name}
+                        key={getWalletId(connector) || connector.name}
                         style={{ marginTop: 6 }}
                       >
                         <ConnectorRow

--- a/packages/create-stark-rn/template/rn/configs/connectors.ts
+++ b/packages/create-stark-rn/template/rn/configs/connectors.ts
@@ -1,31 +1,28 @@
-import { supportedChains } from "@/constants/supportedChains";
 import scaffoldConfig from "@/scaffold.config";
-import { CavosConnector } from "@/services/cavos/connector";
+import { CavosWallet } from "@/services/cavos/connector";
 import { getTargetNetworks } from "@/utils/scaffold-stark/network";
-import { BurnerConnector } from "@scaffold-stark/stark-burner";
-import { InjectedConnector } from "@starknet-react/core";
+import { createBurnerWallet } from "@scaffold-stark/stark-burner";
+import type { WalletWithStarknetFeatures } from "@starknet-io/get-starknet-wallet-standard/features";
 
 const targetNetworks = getTargetNetworks();
 
 export const connectors = getConnectors();
 
-function getConnectors() {
+function getConnectors(): WalletWithStarknetFeatures[] {
   const { targetNetworks } = scaffoldConfig;
 
-  const cavosConnector = new CavosConnector(targetNetworks[0]);
+  const cavosWallet = new CavosWallet(targetNetworks[0]);
 
-  const connectors: InjectedConnector[] = [cavosConnector];
+  const wallets: WalletWithStarknetFeatures[] = [cavosWallet];
 
   const isDevnet = targetNetworks.some(
     (network) => (network.network as string) === "devnet",
   );
   if (isDevnet) {
-    const burnerConnector = new BurnerConnector();
-    burnerConnector.chain = supportedChains.devnet;
-    connectors.push(burnerConnector);
+    wallets.push(createBurnerWallet(targetNetworks[0]));
   }
 
-  return connectors;
+  return wallets;
 }
 
 export const appChains = targetNetworks;

--- a/packages/create-stark-rn/template/rn/configs/provider.ts
+++ b/packages/create-stark-rn/template/rn/configs/provider.ts
@@ -1,10 +1,7 @@
 import scaffoldConfig from "@/scaffold.config";
-import * as chains from "@starknet-react/chains";
-import {
-  jsonRpcProvider,
-  publicProvider,
-  starknetChainId,
-} from "@starknet-react/core";
+import * as chains from "@starknet-start/chains";
+import { jsonRpcProvider, publicProvider } from "@starknet-start/providers";
+import { starknetChainId } from "@starknet-start/react";
 
 const containsDevnet = (networks: readonly chains.Chain[]) => {
   return (
@@ -28,10 +25,14 @@ export const getRpcUrl = (networkName: string): string => {
       rpcUrl = devnetRpcUrl || "http://127.0.0.1:5050";
       break;
     case "sepolia":
-      rpcUrl = sepoliaRpcUrl || "";
+      rpcUrl =
+        sepoliaRpcUrl ||
+        "https://starknet-sepolia.g.alchemy.com/starknet/version/rpc/v0_10/_hKu4IgnPgrF8O82GLuYU";
       break;
     case "mainnet":
-      rpcUrl = mainnetRpcUrl || "";
+      rpcUrl =
+        mainnetRpcUrl ||
+        "https://starknet-mainnet.g.alchemy.com/starknet/version/rpc/v0_10/_hKu4IgnPgrF8O82GLuYU";
       break;
     default:
       rpcUrl = "http://127.0.0.1:5050";

--- a/packages/create-stark-rn/template/rn/constants/supportedChains.ts
+++ b/packages/create-stark-rn/template/rn/constants/supportedChains.ts
@@ -1,4 +1,4 @@
-import * as chains from "@starknet-react/chains";
+import * as chains from "@starknet-start/chains";
 
 const rpcUrlDevnet =
   process.env.EXPO_PUBLIC_DEVNET_PROVIDER_URL || "http://127.0.0.1:5050";

--- a/packages/create-stark-rn/template/rn/hooks/scaffold-stark/__tests__/useAutoConnect-test.ts
+++ b/packages/create-stark-rn/template/rn/hooks/scaffold-stark/__tests__/useAutoConnect-test.ts
@@ -1,23 +1,39 @@
 import { renderHook, waitFor } from "@testing-library/react-native";
-import { useAutoConnect } from "../useAutoConnect";
+import {
+  useAutoConnect,
+  setStorageValue,
+  saveLastUsedConnector,
+  markManualDisconnect,
+} from "../useAutoConnect";
+
+const mockGetItemAsync = jest.fn(() => Promise.resolve(null));
+const mockSetItemAsync = jest.fn(() => Promise.resolve());
+const mockConnect = jest.fn();
 
 // Mock SecureStore
 jest.mock("expo-secure-store", () => ({
-  getItemAsync: jest.fn(() => Promise.resolve(null)),
-  setItemAsync: jest.fn(() => Promise.resolve()),
+  getItemAsync: (...args: any[]) => mockGetItemAsync(...args),
+  setItemAsync: (...args: any[]) => mockSetItemAsync(...args),
 }));
 
 // Mock starknet-react/core
-jest.mock("@starknet-react/core", () => ({
+jest.mock("@starknet-start/react", () => ({
   useConnect: jest.fn(() => ({
-    connect: jest.fn(),
-    connectors: [{ id: "test-connector", ready: true }],
+    connect: mockConnect,
+    connectors: [
+      {
+        id: "test-connector",
+        ready: true,
+        features: { "starknet:walletApi": { id: "test-connector" } },
+      },
+    ],
   })),
   useAccount: jest.fn(() => ({ account: null })),
 }));
 
 // Mock scaffold config
 jest.mock("@/scaffold.config", () => ({
+  __esModule: true,
   default: {
     walletAutoConnect: true,
     autoConnectTTL: 60000,
@@ -27,6 +43,7 @@ jest.mock("@/scaffold.config", () => ({
 describe("useAutoConnect", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGetItemAsync.mockResolvedValue(null);
   });
 
   it("does not throw on render", () => {
@@ -36,26 +53,16 @@ describe("useAutoConnect", () => {
   });
 
   it("loads storage values on mount", async () => {
-    const SecureStore = require("expo-secure-store");
-
     renderHook(() => useAutoConnect());
 
     await waitFor(() => {
-      expect(SecureStore.getItemAsync).toHaveBeenCalled();
+      expect(mockGetItemAsync).toHaveBeenCalled();
     });
   });
 
   it("does not connect when no saved connector", async () => {
-    const { useConnect } = require("@starknet-react/core");
-    const mockConnect = jest.fn();
-    useConnect.mockReturnValue({
-      connect: mockConnect,
-      connectors: [{ id: "test-connector", ready: true }],
-    });
-
     renderHook(() => useAutoConnect());
 
-    // Should not connect since no saved connector in storage
     await waitFor(() => {
       expect(mockConnect).not.toHaveBeenCalled();
     });
@@ -69,17 +76,163 @@ describe("useAutoConnect", () => {
       },
     }));
 
-    const { useConnect } = require("@starknet-react/core");
-    const mockConnect = jest.fn();
-    useConnect.mockReturnValue({
-      connect: mockConnect,
-      connectors: [],
+    renderHook(() => useAutoConnect());
+
+    await waitFor(() => {
+      expect(mockGetItemAsync).toHaveBeenCalled();
     });
+    expect(mockConnect).not.toHaveBeenCalled();
+  });
+
+  it("connects when saved connector matches available connector", async () => {
+    const savedConnector = JSON.stringify({ id: "test-connector" });
+    const lastTime = JSON.stringify(Date.now());
+    const disconnected = JSON.stringify(false);
+
+    mockGetItemAsync
+      .mockResolvedValueOnce(savedConnector)
+      .mockResolvedValueOnce(lastTime)
+      .mockResolvedValueOnce(disconnected);
 
     renderHook(() => useAutoConnect());
 
     await waitFor(() => {
-      expect(mockConnect).not.toHaveBeenCalled();
+      expect(mockConnect).toHaveBeenCalledWith({
+        connector: expect.objectContaining({ id: "test-connector" }),
+      });
     });
+  });
+
+  it("does not connect when manually disconnected", async () => {
+    const savedConnector = JSON.stringify({ id: "test-connector" });
+    const lastTime = JSON.stringify(Date.now());
+    const disconnected = JSON.stringify(true);
+
+    mockGetItemAsync
+      .mockResolvedValueOnce(savedConnector)
+      .mockResolvedValueOnce(lastTime)
+      .mockResolvedValueOnce(disconnected);
+
+    renderHook(() => useAutoConnect());
+
+    await waitFor(() => {
+      expect(mockGetItemAsync).toHaveBeenCalledTimes(3);
+    });
+    expect(mockConnect).not.toHaveBeenCalled();
+  });
+
+  it("does not connect when TTL has expired", async () => {
+    const savedConnector = JSON.stringify({ id: "test-connector" });
+    // Set last connection time to well past the TTL (60000ms)
+    const expiredTime = JSON.stringify(Date.now() - 120000);
+    const disconnected = JSON.stringify(false);
+
+    mockGetItemAsync
+      .mockResolvedValueOnce(savedConnector)
+      .mockResolvedValueOnce(expiredTime)
+      .mockResolvedValueOnce(disconnected);
+
+    renderHook(() => useAutoConnect());
+
+    // TTL expired: source checks `if (ttlExpired || account) return;`
+    // so with TTL expired it should NOT reconnect
+    await waitFor(() => {
+      expect(mockGetItemAsync).toHaveBeenCalledTimes(3);
+    });
+    expect(mockConnect).not.toHaveBeenCalled();
+  });
+
+  it("does not connect when connector is not ready", async () => {
+    const { useConnect } = require("@starknet-start/react");
+    useConnect.mockReturnValue({
+      connect: mockConnect,
+      connectors: [
+        {
+          id: "test-connector",
+          ready: false,
+          features: { "starknet:walletApi": { id: "test-connector" } },
+        },
+      ],
+    });
+
+    const savedConnector = JSON.stringify({ id: "test-connector" });
+    const lastTime = JSON.stringify(Date.now());
+    const disconnected = JSON.stringify(false);
+
+    mockGetItemAsync
+      .mockResolvedValueOnce(savedConnector)
+      .mockResolvedValueOnce(lastTime)
+      .mockResolvedValueOnce(disconnected);
+
+    renderHook(() => useAutoConnect());
+
+    await waitFor(() => {
+      expect(mockGetItemAsync).toHaveBeenCalledTimes(3);
+    });
+    expect(mockConnect).not.toHaveBeenCalled();
+  });
+});
+
+describe("setStorageValue", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("saves value as JSON to SecureStore", async () => {
+    await setStorageValue("key", { foo: "bar" });
+    expect(mockSetItemAsync).toHaveBeenCalledWith(
+      "key",
+      JSON.stringify({ foo: "bar" }),
+    );
+  });
+
+  it("does not throw on storage error", async () => {
+    mockSetItemAsync.mockRejectedValueOnce(new Error("storage error"));
+    await expect(setStorageValue("key", "val")).resolves.not.toThrow();
+  });
+});
+
+describe("saveLastUsedConnector", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("saves connector id, time, and disconnected flag", async () => {
+    await saveLastUsedConnector("braavos", 0);
+
+    expect(mockSetItemAsync).toHaveBeenCalledTimes(3);
+    // Verify the saved connector JSON includes both id and ix
+    expect(mockSetItemAsync).toHaveBeenCalledWith(
+      "scaffold_lastUsedConnector",
+      JSON.stringify({ id: "braavos", ix: 0 }),
+    );
+    expect(mockSetItemAsync).toHaveBeenCalledWith(
+      "scaffold_wasDisconnectedManually",
+      "false",
+    );
+  });
+
+  it("saves connector without ix when not provided", async () => {
+    await saveLastUsedConnector("argentX");
+
+    expect(mockSetItemAsync).toHaveBeenCalledWith(
+      "scaffold_lastUsedConnector",
+      expect.stringContaining('"id":"argentX"'),
+    );
+  });
+});
+
+describe("markManualDisconnect", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("sets wasDisconnectedManually to true", async () => {
+    await markManualDisconnect();
+
+    expect(mockSetItemAsync).toHaveBeenCalledWith(
+      "scaffold_wasDisconnectedManually",
+      "true",
+    );
   });
 });

--- a/packages/create-stark-rn/template/rn/hooks/scaffold-stark/__tests__/useDeployedContractInfo-test.ts
+++ b/packages/create-stark-rn/template/rn/hooks/scaffold-stark/__tests__/useDeployedContractInfo-test.ts
@@ -36,7 +36,7 @@ jest.mock("@/utils/scaffold-stark/contract", () => {
   } as any;
 });
 
-jest.mock("@starknet-react/core", () => ({
+jest.mock("@starknet-start/react", () => ({
   useProvider: () => ({ provider: { getClassHashAt: jest.fn() } }),
 }));
 

--- a/packages/create-stark-rn/template/rn/hooks/scaffold-stark/__tests__/useScaffoldContract-test.ts
+++ b/packages/create-stark-rn/template/rn/hooks/scaffold-stark/__tests__/useScaffoldContract-test.ts
@@ -6,6 +6,9 @@ const mockContract = {
   abi: [{ type: "function", name: "test" }],
 };
 
+const mockConnect = jest.fn();
+const mockCall = jest.fn(async () => "result");
+
 jest.mock("../useDeployedContractInfo", () => ({
   useDeployedContractInfo: jest.fn(() => ({
     data: mockContract,
@@ -13,23 +16,26 @@ jest.mock("../useDeployedContractInfo", () => ({
   })),
 }));
 
-jest.mock("@starknet-react/core", () => ({
-  useProvider: () => ({ provider: { callContract: jest.fn() } }),
-  useAccount: () => ({ account: null }),
+jest.mock("@starknet-start/react", () => ({
+  useProvider: jest.fn(() => ({ provider: { callContract: jest.fn() } })),
 }));
 
 jest.mock("starknet", () => ({
-  Contract: jest.fn().mockImplementation((abi, address, provider) => ({
-    abi,
-    address,
-    provider,
-    connect: jest.fn(),
-    call: jest.fn(),
+  Contract: jest.fn().mockImplementation((_abi, _address, _provider) => ({
+    abi: _abi,
+    address: _address,
+    provider: _provider,
+    connect: mockConnect,
+    call: mockCall,
   })),
   Abi: {},
 }));
 
 describe("useScaffoldContract", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it("returns contract instance when deployed", async () => {
     const { result } = renderHook(() =>
       // @ts-ignore
@@ -69,5 +75,54 @@ describe("useScaffoldContract", () => {
     );
 
     expect(result.current.isLoading).toBe(true);
+  });
+
+  it("does not call contract.connect (account is managed by wallet provider)", async () => {
+    const { result } = renderHook(() =>
+      // @ts-ignore
+      useScaffoldContract({ contractName: "YourContract" }),
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.data).toBeDefined();
+    expect(mockConnect).not.toHaveBeenCalled();
+  });
+
+  it("wraps call method with fallback parseResponse handling", async () => {
+    const originalCall = jest.fn();
+    // First call (with parseResponse: false) throws, second succeeds
+    originalCall
+      .mockRejectedValueOnce(new Error("parse error"))
+      .mockResolvedValueOnce("fallback_result");
+
+    const starknet = require("starknet");
+    starknet.Contract.mockImplementation(() => ({
+      connect: jest.fn(),
+      call: originalCall,
+    }));
+
+    const { result } = renderHook(() =>
+      // @ts-ignore
+      useScaffoldContract({ contractName: "YourContract" }),
+    );
+
+    await waitFor(() => expect(result.current.data).toBeDefined());
+
+    // The wrapped call method should try with parseResponse: false first,
+    // and when that throws, fall back to calling without it
+    const contractInstance = result.current.data;
+    expect(contractInstance).toBeDefined();
+    const callResult = await contractInstance!.call("some_method");
+    expect(callResult).toBe("fallback_result");
+    expect(originalCall).toHaveBeenCalledTimes(2);
+    // First call should include { parseResponse: false }
+    expect(originalCall.mock.calls[0]).toEqual(
+      expect.arrayContaining([
+        "some_method",
+        expect.objectContaining({ parseResponse: false }),
+      ]),
+    );
+    // Second (fallback) call should not include parseResponse
+    expect(originalCall.mock.calls[1][0]).toBe("some_method");
   });
 });

--- a/packages/create-stark-rn/template/rn/hooks/scaffold-stark/__tests__/useScaffoldEventHistory-test.ts
+++ b/packages/create-stark-rn/template/rn/hooks/scaffold-stark/__tests__/useScaffoldEventHistory-test.ts
@@ -55,38 +55,41 @@ jest.mock("starknet", () => ({
   },
 }));
 
-const mockContractData = {
-  address: "0xcontract",
-  abi: [
+const mockEventAbi = {
+  type: "event",
+  name: "contracts::YourContract::Transfer",
+  kind: "struct",
+  members: [
     {
-      type: "event",
-      name: "contracts::YourContract::Transfer",
-      kind: "struct",
-      members: [
-        {
-          name: "from",
-          type: "core::starknet::contract_address::ContractAddress",
-          kind: "key",
-        },
-        {
-          name: "to",
-          type: "core::starknet::contract_address::ContractAddress",
-          kind: "key",
-        },
-        { name: "value", type: "core::integer::u256", kind: "data" },
-      ],
+      name: "from",
+      type: "core::starknet::contract_address::ContractAddress",
+      kind: "key",
     },
+    {
+      name: "to",
+      type: "core::starknet::contract_address::ContractAddress",
+      kind: "key",
+    },
+    { name: "value", type: "core::integer::u256", kind: "data" },
   ],
 };
 
-jest.mock("../useDeployedContractInfo", () => ({
-  useDeployedContractInfo: jest.fn(() => ({
-    data: mockContractData,
-    isLoading: false,
-  })),
+const mockContractData = {
+  address: "0xcontract",
+  abi: [mockEventAbi],
+};
+
+const mockUseDeployedContractInfo = jest.fn(() => ({
+  data: mockContractData,
+  isLoading: false,
 }));
 
-jest.mock("@starknet-react/core", () => ({
+jest.mock("../useDeployedContractInfo", () => ({
+  useDeployedContractInfo: (...args: any[]) =>
+    mockUseDeployedContractInfo(...args),
+}));
+
+jest.mock("@starknet-start/react", () => ({
   useProvider: () => ({ provider: {} }),
 }));
 
@@ -100,7 +103,7 @@ jest.mock("../useTargetNetwork", () => ({
   }),
 }));
 
-jest.mock("@starknet-react/chains", () => ({
+jest.mock("@starknet-start/chains", () => ({
   devnet: { id: 99, network: "devnet" },
 }));
 
@@ -126,14 +129,24 @@ jest.mock("@/utils/scaffold-stark/events", () => ({
 describe("useScaffoldEventHistory", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    jest.useFakeTimers();
+    mockUseDeployedContractInfo.mockReturnValue({
+      data: mockContractData,
+      isLoading: false,
+    });
+    mockGetBlockLatestAccepted.mockResolvedValue({ block_number: 100 });
+    mockGetEvents.mockResolvedValue({
+      events: [
+        {
+          block_hash: "0xblock1",
+          transaction_hash: "0xtx1",
+          keys: ["0xkey1"],
+          data: ["0xdata1"],
+        },
+      ],
+    });
   });
 
-  afterEach(() => {
-    jest.useRealTimers();
-  });
-
-  it("returns initial loading state", () => {
+  it("returns data, isLoading, and error properties", async () => {
     const { useScaffoldEventHistory } = require("../useScaffoldEventHistory");
 
     const { result } = renderHook(() =>
@@ -144,13 +157,12 @@ describe("useScaffoldEventHistory", () => {
       }),
     );
 
-    // Should have data array (possibly empty) and loading status
     expect(result.current).toHaveProperty("data");
     expect(result.current).toHaveProperty("isLoading");
     expect(result.current).toHaveProperty("error");
   });
 
-  it("fetches events and returns parsed data", async () => {
+  it("fetches events and calls getEvents", async () => {
     const { useScaffoldEventHistory } = require("../useScaffoldEventHistory");
 
     const { result } = renderHook(() =>
@@ -162,10 +174,7 @@ describe("useScaffoldEventHistory", () => {
     );
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
-
-    // The hook should have called getEvents
     expect(mockGetEvents).toHaveBeenCalled();
-    expect(result.current.data).toBeDefined();
     expect(Array.isArray(result.current.data)).toBe(true);
   });
 
@@ -185,103 +194,8 @@ describe("useScaffoldEventHistory", () => {
     expect(mockGetEvents).not.toHaveBeenCalled();
   });
 
-  it("handles contract not deployed", async () => {
-    const { useDeployedContractInfo } = require("../useDeployedContractInfo");
-    useDeployedContractInfo.mockReturnValue({
-      data: undefined,
-      isLoading: false,
-    });
-
-    const { useScaffoldEventHistory } = require("../useScaffoldEventHistory");
-
-    // When abi is undefined, matchingAbiEvents will be undefined and the hook
-    // won't throw because the filter produces undefined
-    const { result } = renderHook(() =>
-      useScaffoldEventHistory({
-        contractName: "YourContract" as any,
-        eventName: "Transfer" as any,
-        fromBlock: BigInt(0),
-      }),
-    );
-
-    await waitFor(() => expect(result.current.isLoading).toBe(false));
-  });
-
-  it("includes block data when blockData flag is true", async () => {
-    const { useDeployedContractInfo } = require("../useDeployedContractInfo");
-    useDeployedContractInfo.mockReturnValue({
-      data: mockContractData,
-      isLoading: false,
-    });
-
-    const { useScaffoldEventHistory } = require("../useScaffoldEventHistory");
-
-    const { result } = renderHook(() =>
-      useScaffoldEventHistory({
-        contractName: "YourContract" as any,
-        eventName: "Transfer" as any,
-        fromBlock: BigInt(0),
-        blockData: true,
-      }),
-    );
-
-    await waitFor(() => expect(result.current.isLoading).toBe(false));
-    // getBlockWithTxHashes should be called when blockData is true
-    expect(mockGetBlockWithTxHashes).toHaveBeenCalled();
-  });
-
-  it("includes transaction data when transactionData flag is true", async () => {
-    const { useDeployedContractInfo } = require("../useDeployedContractInfo");
-    useDeployedContractInfo.mockReturnValue({
-      data: mockContractData,
-      isLoading: false,
-    });
-
-    const { useScaffoldEventHistory } = require("../useScaffoldEventHistory");
-
-    const { result } = renderHook(() =>
-      useScaffoldEventHistory({
-        contractName: "YourContract" as any,
-        eventName: "Transfer" as any,
-        fromBlock: BigInt(0),
-        transactionData: true,
-      }),
-    );
-
-    await waitFor(() => expect(result.current.isLoading).toBe(false));
-    expect(mockGetTransactionByHash).toHaveBeenCalled();
-  });
-
-  it("includes receipt data when receiptData flag is true", async () => {
-    const { useDeployedContractInfo } = require("../useDeployedContractInfo");
-    useDeployedContractInfo.mockReturnValue({
-      data: mockContractData,
-      isLoading: false,
-    });
-
-    const { useScaffoldEventHistory } = require("../useScaffoldEventHistory");
-
-    const { result } = renderHook(() =>
-      useScaffoldEventHistory({
-        contractName: "YourContract" as any,
-        eventName: "Transfer" as any,
-        fromBlock: BigInt(0),
-        receiptData: true,
-      }),
-    );
-
-    await waitFor(() => expect(result.current.isLoading).toBe(false));
-    expect(mockGetTransactionReceipt).toHaveBeenCalled();
-  });
-
   it("handles errors during event fetching", async () => {
-    mockGetBlockLatestAccepted.mockRejectedValueOnce(new Error("RPC error"));
-
-    const { useDeployedContractInfo } = require("../useDeployedContractInfo");
-    useDeployedContractInfo.mockReturnValue({
-      data: mockContractData,
-      isLoading: false,
-    });
+    mockGetBlockLatestAccepted.mockRejectedValue(new Error("RPC error"));
 
     const { useScaffoldEventHistory } = require("../useScaffoldEventHistory");
 
@@ -297,17 +211,62 @@ describe("useScaffoldEventHistory", () => {
     expect(result.current.error).toBeDefined();
   });
 
-  it("returns empty data when no events match", async () => {
-    mockGetEvents.mockResolvedValueOnce({ events: [] });
+  it("fetches block data when blockData flag is set", async () => {
+    const { useScaffoldEventHistory } = require("../useScaffoldEventHistory");
 
-    const { useDeployedContractInfo } = require("../useDeployedContractInfo");
-    useDeployedContractInfo.mockReturnValue({
-      data: mockContractData,
-      isLoading: false,
+    renderHook(() =>
+      useScaffoldEventHistory({
+        contractName: "YourContract" as any,
+        eventName: "Transfer" as any,
+        fromBlock: BigInt(0),
+        blockData: true,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockGetBlockWithTxHashes).toHaveBeenCalled();
     });
+  });
 
-    const starknet = require("starknet");
-    starknet.events.parseEvents.mockReturnValueOnce([]);
+  it("fetches transaction data when transactionData flag is set", async () => {
+    const { useScaffoldEventHistory } = require("../useScaffoldEventHistory");
+
+    renderHook(() =>
+      useScaffoldEventHistory({
+        contractName: "YourContract" as any,
+        eventName: "Transfer" as any,
+        fromBlock: BigInt(0),
+        transactionData: true,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockGetTransactionByHash).toHaveBeenCalled();
+    });
+  });
+
+  it("fetches receipt data when receiptData flag is set", async () => {
+    const { useScaffoldEventHistory } = require("../useScaffoldEventHistory");
+
+    renderHook(() =>
+      useScaffoldEventHistory({
+        contractName: "YourContract" as any,
+        eventName: "Transfer" as any,
+        fromBlock: BigInt(0),
+        receiptData: true,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockGetTransactionReceipt).toHaveBeenCalled();
+    });
+  });
+
+  it("does not fetch when contract is still loading", async () => {
+    mockUseDeployedContractInfo.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    });
 
     const { useScaffoldEventHistory } = require("../useScaffoldEventHistory");
 
@@ -319,7 +278,26 @@ describe("useScaffoldEventHistory", () => {
       }),
     );
 
+    // Should still be in loading state
+    expect(result.current.isLoading).toBe(true);
+    expect(mockGetEvents).not.toHaveBeenCalled();
+  });
+
+  it("passes watch flag correctly to the hook", async () => {
+    const { useScaffoldEventHistory } = require("../useScaffoldEventHistory");
+
+    const { result } = renderHook(() =>
+      useScaffoldEventHistory({
+        contractName: "YourContract" as any,
+        eventName: "Transfer" as any,
+        fromBlock: BigInt(0),
+        watch: true,
+      }),
+    );
+
+    // When watch is true, the hook still performs the initial fetch
     await waitFor(() => expect(result.current.isLoading).toBe(false));
-    expect(result.current.data).toBeDefined();
+    expect(mockGetEvents).toHaveBeenCalled();
+    expect(Array.isArray(result.current.data)).toBe(true);
   });
 });

--- a/packages/create-stark-rn/template/rn/hooks/scaffold-stark/__tests__/useScaffoldMultiWriteContract-test.ts
+++ b/packages/create-stark-rn/template/rn/hooks/scaffold-stark/__tests__/useScaffoldMultiWriteContract-test.ts
@@ -20,15 +20,18 @@ jest.mock("../useTargetNetwork", () => ({
   useTargetNetwork: jest.fn(),
 }));
 
-jest.mock("@starknet-react/core", () => ({
+jest.mock("@starknet-start/react", () => ({
   useSendTransaction: jest.fn(),
   useNetwork: jest.fn(() => ({ chain: { id: 1 } })),
 }));
 
 jest.mock("starknet", () => ({
-  Contract: jest.fn().mockImplementation(() => ({
+  // The source uses new StarknetJsContract({ abi, address }) (object form)
+  Contract: jest.fn().mockImplementation(({ abi, address } = {}) => ({
+    abi,
+    address,
     populate: jest.fn().mockReturnValue({
-      contractAddress: "0x123",
+      contractAddress: address || "0x123",
       entrypoint: "transfer",
       calldata: ["0x1234", "1000"],
     }),
@@ -36,9 +39,11 @@ jest.mock("starknet", () => ({
   RpcProvider: jest.fn(),
 }));
 
+const mockWriteTransaction = jest.fn().mockResolvedValue("mock-tx-hash");
+
 jest.mock("../useTransactor", () => ({
   useTransactor: jest.fn().mockReturnValue({
-    writeTransaction: jest.fn().mockResolvedValue("mock-tx-hash"),
+    writeTransaction: mockWriteTransaction,
     sendTransactionInstance: { sendAsync: jest.fn(), status: "idle" },
     transactionReceiptInstance: { data: null, status: "idle" },
   }),
@@ -47,7 +52,7 @@ jest.mock("../useTransactor", () => ({
 describe("useScaffoldMultiWriteContract Hook", () => {
   const mockSendTransaction = jest.fn();
   const { useNetwork, useSendTransaction } = jest.requireMock(
-    "@starknet-react/core",
+    "@starknet-start/react",
   );
   const { useTargetNetwork } = jest.requireMock("../useTargetNetwork");
   const { useTransactor } = jest.requireMock("../useTransactor");
@@ -63,8 +68,9 @@ describe("useScaffoldMultiWriteContract Hook", () => {
       sendAsync: mockSendTransaction,
       status: "idle",
     });
+    mockWriteTransaction.mockResolvedValue("mock-tx-hash");
     (useTransactor as jest.Mock).mockReturnValue({
-      writeTransaction: jest.fn().mockResolvedValue("mock-tx-hash"),
+      writeTransaction: mockWriteTransaction,
       sendTransactionInstance: { sendAsync: jest.fn(), status: "idle" },
       transactionReceiptInstance: { data: null, status: "idle" },
     });
@@ -98,8 +104,142 @@ describe("useScaffoldMultiWriteContract Hook", () => {
       await result.current.sendAsync();
     });
 
-    const transactor = useTransactor();
-    expect(transactor.writeTransaction).not.toHaveBeenCalled();
+    expect(mockWriteTransaction).not.toHaveBeenCalled();
+  });
+
+  it("should return early when on wrong network", async () => {
+    useTargetNetwork.mockReturnValue({
+      targetNetwork: { network: "testNetwork", id: 2 },
+    });
+
+    const { result } = renderHook(() =>
+      useScaffoldMultiWriteContract({
+        calls: [
+          { contractName: "Strk", functionName: "transfer", args: ["arg1", 1] },
+        ],
+      }),
+    );
+
+    await act(async () => {
+      await result.current.sendAsync();
+    });
+
+    expect(mockWriteTransaction).not.toHaveBeenCalled();
+  });
+
+  it("should send batch transaction with parsed calls", async () => {
+    const { result } = renderHook(() =>
+      useScaffoldMultiWriteContract({
+        calls: [
+          { contractName: "Strk", functionName: "transfer", args: ["arg1", 1] },
+        ],
+      }),
+    );
+
+    await act(async () => {
+      await result.current.sendAsync();
+    });
+
+    expect(mockWriteTransaction).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          contractAddress: "0x12345",
+          entrypoint: "transfer",
+        }),
+      ]),
+    );
+  });
+
+  it("should handle raw Call objects", async () => {
+    const rawCall = {
+      contractAddress: "0xraw",
+      entrypoint: "raw_fn",
+      calldata: ["1", "2"],
+    };
+
+    const { result } = renderHook(() =>
+      useScaffoldMultiWriteContract({
+        calls: [rawCall as any],
+      }),
+    );
+
+    await act(async () => {
+      await result.current.sendAsync();
+    });
+
+    expect(mockWriteTransaction).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          contractAddress: "0xraw",
+          entrypoint: "raw_fn",
+        }),
+      ]),
+    );
+  });
+
+  it("should handle empty calls array", async () => {
+    const { result } = renderHook(() =>
+      useScaffoldMultiWriteContract({
+        calls: [],
+      }),
+    );
+
+    await act(async () => {
+      await result.current.sendAsync();
+    });
+
+    expect(mockWriteTransaction).toHaveBeenCalledWith([]);
+  });
+
+  it("should handle undefined calls", async () => {
+    const { result } = renderHook(() =>
+      useScaffoldMultiWriteContract({
+        calls: undefined as any,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.sendAsync();
+    });
+
+    expect(mockWriteTransaction).toHaveBeenCalledWith([]);
+  });
+
+  it("should re-throw transaction errors", async () => {
+    mockWriteTransaction.mockRejectedValue(new Error("tx failed"));
+
+    const { result } = renderHook(() =>
+      useScaffoldMultiWriteContract({
+        calls: [
+          { contractName: "Strk", functionName: "transfer", args: ["arg1", 1] },
+        ],
+      }),
+    );
+
+    await act(async () => {
+      await expect(result.current.sendAsync()).rejects.toThrow("tx failed");
+    });
+  });
+
+  it("spreads sendTransactionInstance properties", () => {
+    (useTransactor as jest.Mock).mockReturnValue({
+      writeTransaction: mockWriteTransaction,
+      sendTransactionInstance: {
+        sendAsync: jest.fn(),
+        status: "loading",
+        data: "0xdata",
+      },
+      transactionReceiptInstance: { data: null, status: "idle" },
+    });
+
+    const { result } = renderHook(() =>
+      useScaffoldMultiWriteContract({
+        calls: [],
+      }),
+    );
+
+    expect(result.current.status).toBe("loading");
+    expect(result.current.data).toBe("0xdata");
   });
 });
 
@@ -115,5 +255,14 @@ describe("createContractCall Function", () => {
       functionName: "transfer",
       args: ["arg1", 1],
     });
+  });
+
+  it("should handle empty args", () => {
+    const contractCall = createContractCall(
+      "Strk" as any,
+      "get_balance" as unknown as never,
+      [] as unknown as never,
+    );
+    expect(contractCall.args).toEqual([]);
   });
 });

--- a/packages/create-stark-rn/template/rn/hooks/scaffold-stark/__tests__/useScaffoldReadContract-test.ts
+++ b/packages/create-stark-rn/template/rn/hooks/scaffold-stark/__tests__/useScaffoldReadContract-test.ts
@@ -1,4 +1,4 @@
-import * as core from "@starknet-react/core";
+import * as core from "@starknet-start/react";
 import { renderHook } from "@testing-library/react-native";
 
 jest.mock("@/utils/scaffold-stark/contract", () => ({
@@ -15,7 +15,7 @@ jest.mock("../useDeployedContractInfo", () => ({
   }),
 }));
 
-jest.mock("@starknet-react/core", () => {
+jest.mock("@starknet-start/react", () => {
   return {
     useReadContract: jest.fn(() => ({ data: "ok", isLoading: false })),
   };

--- a/packages/create-stark-rn/template/rn/hooks/scaffold-stark/__tests__/useScaffoldStarkProfile-test.ts
+++ b/packages/create-stark-rn/template/rn/hooks/scaffold-stark/__tests__/useScaffoldStarkProfile-test.ts
@@ -1,7 +1,24 @@
-import { fetchProfileFromApi } from "../useScaffoldStarkProfile";
+import { renderHook, waitFor } from "@testing-library/react-native";
+import {
+  fetchProfileFromApi,
+  useScaffoldStarkProfile,
+} from "../useScaffoldStarkProfile";
 
 // Mock fetch
 global.fetch = jest.fn();
+
+// Mock scaffold config - default to sepolia (supported network)
+jest.mock("@/scaffold.config", () => ({
+  __esModule: true,
+  default: {
+    targetNetworks: [{ network: "sepolia" }],
+  },
+}));
+
+jest.mock("@starknet-start/chains", () => ({
+  devnet: { network: "devnet" },
+  mainnet: { network: "mainnet" },
+}));
 
 describe("fetchProfileFromApi", () => {
   beforeEach(() => {
@@ -95,5 +112,110 @@ describe("fetchProfileFromApi", () => {
       "domain_to_data",
     );
     expect((global.fetch as jest.Mock).mock.calls[2][0]).toContain("uri");
+  });
+
+  it("uses sepolia API URL for sepolia network", async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      text: () => Promise.resolve("No data found"),
+    });
+
+    await fetchProfileFromApi("0x123");
+
+    expect((global.fetch as jest.Mock).mock.calls[0][0]).toContain(
+      "sepolia.api.starknet.id",
+    );
+  });
+});
+
+describe("useScaffoldStarkProfile", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns loading false and profile data after fetch", async () => {
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ domain: "user.stark" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({ id: "456", domain: { domain: "user.stark" } }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ image: "https://img.com/user.png" }),
+      });
+
+    const { result } = renderHook(() =>
+      useScaffoldStarkProfile("0xuser" as any),
+    );
+
+    // Should start loading
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.data).toEqual({
+      name: "user.stark",
+      profilePicture: "https://img.com/user.png",
+    });
+  });
+
+  it("returns empty profile and skips fetch when address is undefined", async () => {
+    const { result } = renderHook(() =>
+      useScaffoldStarkProfile(undefined),
+    );
+
+    // Should immediately set empty profile (not loading) and never call fetch
+    await waitFor(() => {
+      expect(result.current.data).toEqual({
+        name: "",
+        profilePicture: "",
+      });
+    });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("returns empty profile when API returns error", async () => {
+    // fetchProfileFromApi catches errors internally and returns empty profile
+    (global.fetch as jest.Mock).mockRejectedValueOnce(
+      new Error("Unexpected error"),
+    );
+
+    const { result } = renderHook(() =>
+      useScaffoldStarkProfile("0xuser" as any),
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.data).toEqual({
+      name: "",
+      profilePicture: "",
+    });
+  });
+
+  it("returns empty profile for unsupported network (devnet)", async () => {
+    // Override config to use devnet (unsupported for profiles)
+    const scaffoldConfig = require("@/scaffold.config").default;
+    const originalNetworks = scaffoldConfig.targetNetworks;
+    scaffoldConfig.targetNetworks = [{ network: "devnet" }];
+
+    const { result } = renderHook(() =>
+      useScaffoldStarkProfile("0xuser" as any),
+    );
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual({
+        name: "",
+        profilePicture: "",
+      });
+    });
+
+    expect(global.fetch).not.toHaveBeenCalled();
+
+    // Restore
+    scaffoldConfig.targetNetworks = originalNetworks;
   });
 });

--- a/packages/create-stark-rn/template/rn/hooks/scaffold-stark/__tests__/useScaffoldStrkBalance-test.ts
+++ b/packages/create-stark-rn/template/rn/hooks/scaffold-stark/__tests__/useScaffoldStrkBalance-test.ts
@@ -11,7 +11,7 @@ jest.mock("../useDeployedContractInfo", () => ({
   })),
 }));
 
-jest.mock("@starknet-react/core", () => ({
+jest.mock("@starknet-start/react", () => ({
   useReadContract: (...args: any[]) => mockUseReadContract(...args),
 }));
 
@@ -19,7 +19,7 @@ jest.mock("starknet", () => ({
   BlockNumber: {},
 }));
 
-jest.mock("@/utils/scaffold-stark/ethUnits", () => ({
+jest.mock("viem", () => ({
   formatUnits: (value: bigint, decimals: number) => {
     return (Number(value) / 10 ** decimals).toString();
   },
@@ -62,6 +62,7 @@ describe("useScaffoldStrkBalance", () => {
         address: "0xstrk",
         watch: true,
         enabled: true,
+        blockIdentifier: "pre_confirmed",
       }),
     );
   });
@@ -113,7 +114,7 @@ describe("useScaffoldStrkBalance", () => {
 
     expect(result.current.isLoading).toBe(true);
     expect(result.current.error).toBeDefined();
-    expect(result.current.refetch).toBeInstanceOf(Function);
+    expect(typeof result.current.refetch).toBe("function");
   });
 
   it("uses Strk contract from useDeployedContractInfo", () => {

--- a/packages/create-stark-rn/template/rn/hooks/scaffold-stark/__tests__/useScaffoldWriteContract-test.ts
+++ b/packages/create-stark-rn/template/rn/hooks/scaffold-stark/__tests__/useScaffoldWriteContract-test.ts
@@ -11,7 +11,7 @@ jest.mock("starknet", () => ({
   })),
 }));
 
-jest.mock("@starknet-react/core", () => ({
+jest.mock("@starknet-start/react", () => ({
   useSendTransaction: jest.fn(),
   useNetwork: jest.fn(() => ({ chain: { id: 1 } })),
 }));
@@ -44,7 +44,7 @@ describe("useScaffoldWriteContract", () => {
   const { useDeployedContractInfo } = jest.requireMock(
     "../useDeployedContractInfo",
   );
-  const { useSendTransaction } = jest.requireMock("@starknet-react/core");
+  const { useSendTransaction } = jest.requireMock("@starknet-start/react");
   const { useTransactor, __mocks: transactorMocks } =
     jest.requireMock("../useTransactor");
   const { useTargetNetwork } = jest.requireMock("../useTargetNetwork");

--- a/packages/create-stark-rn/template/rn/hooks/scaffold-stark/__tests__/useSwitchNetwork-test.ts
+++ b/packages/create-stark-rn/template/rn/hooks/scaffold-stark/__tests__/useSwitchNetwork-test.ts
@@ -4,7 +4,7 @@ const mockSetTargetNetwork = jest.fn();
 const mockRequest = jest.fn();
 
 // Mock starknet-react/core
-jest.mock("@starknet-react/core", () => ({
+jest.mock("@starknet-start/react", () => ({
   useAccount: jest.fn(() => ({
     connector: {
       request: mockRequest,

--- a/packages/create-stark-rn/template/rn/hooks/scaffold-stark/__tests__/useTargetNetwork-test.ts
+++ b/packages/create-stark-rn/template/rn/hooks/scaffold-stark/__tests__/useTargetNetwork-test.ts
@@ -16,7 +16,7 @@ jest.mock("@/stores/store", () => ({
     }),
 }));
 
-jest.mock("@starknet-react/core", () => ({
+jest.mock("@starknet-start/react", () => ({
   useAccount: () => ({ chainId: 2 }),
 }));
 

--- a/packages/create-stark-rn/template/rn/hooks/scaffold-stark/__tests__/useTransactor-test.ts
+++ b/packages/create-stark-rn/template/rn/hooks/scaffold-stark/__tests__/useTransactor-test.ts
@@ -1,13 +1,15 @@
 import { act, renderHook } from "@testing-library/react-native";
 
+const mockAppToast = {
+  showPersistentInfo: jest.fn(),
+  showWaiting: jest.fn(),
+  showError: jest.fn(),
+  showSuccess: jest.fn(),
+  hide: jest.fn(),
+};
+
 jest.mock("@/utils/scaffold-stark/toast", () => ({
-  appToast: {
-    showPersistentInfo: jest.fn(),
-    showWaiting: jest.fn(),
-    showError: jest.fn(),
-    showSuccess: jest.fn(),
-    hide: jest.fn(),
-  },
+  appToast: mockAppToast,
 }));
 
 jest.mock("@/utils/scaffold-stark/network", () => ({
@@ -15,16 +17,14 @@ jest.mock("@/utils/scaffold-stark/network", () => ({
     `https://explorer/tx/${hash}`,
 }));
 
-jest.mock("@starknet-react/core", () => ({
-  useAccount: () => ({
-    account: {
-      execute: jest.fn(async () => ({ transaction_hash: "0xhash" })),
-      getChainId: jest.fn(async () => 1),
-      estimateInvokeFee: jest.fn(async () => ({ overall_fee: "0x10" })),
-    },
-  }),
-  useSendTransaction: () => ({ sendAsync: jest.fn(async () => "0xhash") }),
-  useTransactionReceipt: () => ({ data: {}, status: "success" }),
+const mockSendAsync = jest.fn(async () => "0xhash");
+
+jest.mock("@starknet-start/react", () => ({
+  useAccount: jest.fn(() => ({
+    status: "connected",
+  })),
+  useSendTransaction: jest.fn(() => ({ sendAsync: mockSendAsync })),
+  useTransactionReceipt: jest.fn(() => ({ data: {}, status: "pending" })),
 }));
 
 jest.mock("../useTargetNetwork", () => ({
@@ -32,14 +32,211 @@ jest.mock("../useTargetNetwork", () => ({
 }));
 
 describe("useTransactor", () => {
-  it("sends transaction and manages state/toasts", async () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSendAsync.mockResolvedValue("0xhash");
+  });
+
+  it("sends transaction via sendAsync (withSendTransaction=true)", async () => {
     const { useTransactor } = require("../useTransactor");
     const { result } = renderHook(() => useTransactor());
+
+    await act(async () => {
+      const hash = await result.current.writeTransaction(
+        [{ to: "0xabc" }] as any,
+        true,
+      );
+      expect(hash).toBe("0xhash");
+    });
+
+    expect(mockSendAsync).toHaveBeenCalled();
+    expect(mockAppToast.showPersistentInfo).toHaveBeenCalledWith(
+      "Awaiting user confirmation",
+      undefined,
+      expect.any(Object),
+    );
+  });
+
+  it("sends transaction via walletClient.execute (withSendTransaction=false)", async () => {
+    const mockExecute = jest.fn(async () => ({ transaction_hash: "0xhash" }));
+    const mockEstimateInvokeFee = jest.fn(async () => ({ overall_fee: "0x10" }));
+    const externalAccount = {
+      execute: mockExecute,
+      estimateInvokeFee: mockEstimateInvokeFee,
+    };
+
+    const { useTransactor } = require("../useTransactor");
+    const { result } = renderHook(() => useTransactor(externalAccount as any));
+
+    await act(async () => {
+      const hash = await result.current.writeTransaction(
+        [{ to: "0xabc" }] as any,
+        false,
+      );
+      expect(hash).toBe("0xhash");
+    });
+
+    expect(mockExecute).toHaveBeenCalled();
+    expect(mockEstimateInvokeFee).toHaveBeenCalled();
+    // Verify fee estimation: overall_fee "0x10" (16) * 1.5 = 24 = 0x18
+    const executeArgs = mockExecute.mock.calls[0];
+    expect(executeArgs[1]).toEqual(
+      expect.objectContaining({
+        maxFee: "0x18",
+      }),
+    );
+  });
+
+  it("falls back to default fee values when estimation fails", async () => {
+    const mockExecute = jest.fn(async () => ({ transaction_hash: "0xhash" }));
+    const mockEstimateInvokeFee = jest.fn().mockRejectedValue(new Error("estimation failed"));
+    const externalAccount = {
+      execute: mockExecute,
+      estimateInvokeFee: mockEstimateInvokeFee,
+    };
+
+    const { useTransactor } = require("../useTransactor");
+    const { result } = renderHook(() => useTransactor(externalAccount as any));
+
+    await act(async () => {
+      const hash = await result.current.writeTransaction(
+        [{ to: "0xabc" }] as any,
+        false,
+      );
+      expect(hash).toBe("0xhash");
+    });
+
+    expect(mockExecute).toHaveBeenCalledTimes(1);
+    const callArgs = mockExecute.mock.calls[0];
+    expect(callArgs[1]).toEqual(
+      expect.objectContaining({
+        maxFee: "0x1000000000",
+        resourceBounds: expect.objectContaining({
+          l1_gas: expect.objectContaining({ max_amount: 0x1000000n }),
+          l2_gas: expect.objectContaining({ max_amount: 0x1000000n }),
+        }),
+      }),
+    );
+  });
+
+  it("shows error toast when wallet is not connected", async () => {
+    const { useAccount } = require("@starknet-start/react");
+    useAccount.mockReturnValueOnce({ status: "disconnected" });
+
+    const { useTransactor } = require("../useTransactor");
+    const { result } = renderHook(() => useTransactor());
+
     await act(async () => {
       const hash = await result.current.writeTransaction([
         { to: "0xabc" },
       ] as any);
+      expect(hash).toBeUndefined();
+    });
+
+    expect(mockAppToast.showError).toHaveBeenCalledWith("Wallet not connected");
+  });
+
+  it("throws error when tx is null", async () => {
+    const { useTransactor } = require("../useTransactor");
+    const { result } = renderHook(() => useTransactor());
+
+    await act(async () => {
+      await expect(
+        result.current.writeTransaction(null as any),
+      ).rejects.toThrow("Incorrect transaction passed to transactor");
+    });
+
+    expect(mockAppToast.showError).toHaveBeenCalled();
+  });
+
+  it("shows error toast and re-throws on transaction failure", async () => {
+    mockSendAsync.mockRejectedValue(
+      new Error('Contract execution error: "insufficient funds"}'),
+    );
+
+    const { useTransactor } = require("../useTransactor");
+    const { result } = renderHook(() => useTransactor());
+
+    await act(async () => {
+      await expect(
+        result.current.writeTransaction([{ to: "0xabc" }] as any, true),
+      ).rejects.toThrow();
+    });
+
+    expect(mockAppToast.showError).toHaveBeenCalledWith(
+      expect.stringContaining("insufficient funds"),
+    );
+  });
+
+  it("handles sendAsync returning object with transaction_hash", async () => {
+    mockSendAsync.mockResolvedValue({ transaction_hash: "0xobj_hash" });
+
+    const { useTransactor } = require("../useTransactor");
+    const { result } = renderHook(() => useTransactor());
+
+    await act(async () => {
+      const hash = await result.current.writeTransaction(
+        [{ to: "0xabc" }] as any,
+        true,
+      );
+      expect(hash).toBe("0xobj_hash");
+    });
+  });
+
+  it("exposes transactionReceiptInstance and sendTransactionInstance", () => {
+    const { useTransactor } = require("../useTransactor");
+    const { result } = renderHook(() => useTransactor());
+
+    expect(result.current.transactionReceiptInstance).toBeDefined();
+    expect(result.current.sendTransactionInstance).toBeDefined();
+  });
+
+  it("shows waiting toast with block explorer URL after sending", async () => {
+    const { useTransactor } = require("../useTransactor");
+    const { result } = renderHook(() => useTransactor());
+
+    await act(async () => {
+      await result.current.writeTransaction([{ to: "0xabc" }] as any, true);
+    });
+
+    expect(mockAppToast.showWaiting).toHaveBeenCalledWith(
+      "Waiting for transaction to complete",
+      expect.stringContaining("https://explorer/tx/"),
+    );
+  });
+
+  it("accepts an external walletClient for direct execution", async () => {
+    const externalAccount = {
+      execute: jest.fn(async () => ({ transaction_hash: "0xext" })),
+      estimateInvokeFee: jest.fn(async () => ({ overall_fee: "0x1" })),
+    };
+
+    const { useTransactor } = require("../useTransactor");
+    const { result } = renderHook(() => useTransactor(externalAccount as any));
+
+    await act(async () => {
+      const hash = await result.current.writeTransaction(
+        [{ to: "0xabc" }] as any,
+        false,
+      );
+      expect(hash).toBe("0xext");
+    });
+
+    expect(externalAccount.execute).toHaveBeenCalled();
+  });
+
+  it("falls back to sendAsync when withSendTransaction=false but no walletClient", async () => {
+    const { useTransactor } = require("../useTransactor");
+    const { result } = renderHook(() => useTransactor());
+
+    await act(async () => {
+      const hash = await result.current.writeTransaction(
+        [{ to: "0xabc" }] as any,
+        false,
+      );
       expect(hash).toBe("0xhash");
     });
+
+    expect(mockSendAsync).toHaveBeenCalled();
   });
 });

--- a/packages/create-stark-rn/template/rn/hooks/scaffold-stark/__tests__/useWebSocketData-test.ts
+++ b/packages/create-stark-rn/template/rn/hooks/scaffold-stark/__tests__/useWebSocketData-test.ts
@@ -1,5 +1,11 @@
-import { renderHook, act } from "@testing-library/react-native";
+import { renderHook, act, waitFor } from "@testing-library/react-native";
 import { useWebSocketData } from "../useWebSocketData";
+
+const mockSubscribeNewHeads = jest.fn();
+const mockSubscribeNewTransactionReceipts = jest.fn();
+const mockSubscribeTransactionStatus = jest.fn();
+const mockUnsubscribe = jest.fn();
+const mockOn = jest.fn();
 
 // Mock useTargetNetwork
 jest.mock("../useTargetNetwork", () => ({
@@ -12,14 +18,30 @@ jest.mock("../useTargetNetwork", () => ({
   })),
 }));
 
-// Mock websocket service - return null to avoid async issues
+// Mock websocket service
 jest.mock("@/services/web3/websocket", () => ({
-  getSharedWebSocketChannel: jest.fn(() => Promise.resolve(null)),
+  getSharedWebSocketChannel: jest.fn(),
 }));
 
 describe("useWebSocketData", () => {
+  const { getSharedWebSocketChannel } = require("@/services/web3/websocket");
+
   beforeEach(() => {
     jest.clearAllMocks();
+    mockOn.mockReset();
+
+    mockSubscribeNewHeads.mockResolvedValue({
+      on: mockOn,
+      unsubscribe: mockUnsubscribe,
+    });
+    mockSubscribeNewTransactionReceipts.mockResolvedValue({
+      on: mockOn,
+      unsubscribe: mockUnsubscribe,
+    });
+    mockSubscribeTransactionStatus.mockResolvedValue({
+      on: mockOn,
+      unsubscribe: mockUnsubscribe,
+    });
   });
 
   it("starts with idle status when disabled", () => {
@@ -82,6 +104,184 @@ describe("useWebSocketData", () => {
       );
 
       expect(result.current.status).toBe("idle");
+    });
+  });
+
+  it("sets error status when WebSocket channel is unavailable", async () => {
+    getSharedWebSocketChannel.mockResolvedValue(null);
+
+    const { result } = renderHook(() =>
+      useWebSocketData({
+        topic: "newHeads",
+        enabled: true,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.status).toBe("error");
+      expect(result.current.error?.message).toBe(
+        "WebSocket channel unavailable",
+      );
+    });
+  });
+
+  it("subscribes to newHeads topic", async () => {
+    const mockChannel = {
+      subscribeNewHeads: mockSubscribeNewHeads,
+      subscribeNewTransactionReceipts: mockSubscribeNewTransactionReceipts,
+      subscribeTransactionStatus: mockSubscribeTransactionStatus,
+    };
+    getSharedWebSocketChannel.mockResolvedValue(mockChannel);
+
+    const { result } = renderHook(() =>
+      useWebSocketData({
+        topic: "newHeads",
+        enabled: true,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockSubscribeNewHeads).toHaveBeenCalled();
+    });
+
+    // Subscription was established; the status will transition to "connected"
+    // after a 150ms anti-flicker delay handled internally by the hook.
+    expect(["connecting", "connected"]).toContain(result.current.status);
+  });
+
+  it("subscribes to newTransactionReceipts topic", async () => {
+    const mockChannel = {
+      subscribeNewHeads: mockSubscribeNewHeads,
+      subscribeNewTransactionReceipts: mockSubscribeNewTransactionReceipts,
+      subscribeTransactionStatus: mockSubscribeTransactionStatus,
+    };
+    getSharedWebSocketChannel.mockResolvedValue(mockChannel);
+
+    renderHook(() =>
+      useWebSocketData({
+        topic: "newTransactionReceipts",
+        enabled: true,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockSubscribeNewTransactionReceipts).toHaveBeenCalled();
+    });
+  });
+
+  it("subscribes to transactionStatus topic", async () => {
+    const mockChannel = {
+      subscribeNewHeads: mockSubscribeNewHeads,
+      subscribeNewTransactionReceipts: mockSubscribeNewTransactionReceipts,
+      subscribeTransactionStatus: mockSubscribeTransactionStatus,
+    };
+    getSharedWebSocketChannel.mockResolvedValue(mockChannel);
+
+    renderHook(() =>
+      useWebSocketData({
+        topic: "transactionStatus",
+        params: { transaction_hash: "0xtx" } as any,
+        enabled: true,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockSubscribeTransactionStatus).toHaveBeenCalled();
+    });
+  });
+
+  it("collects received messages in data array (newest first)", async () => {
+    const mockChannel = {
+      subscribeNewHeads: mockSubscribeNewHeads,
+      subscribeNewTransactionReceipts: mockSubscribeNewTransactionReceipts,
+      subscribeTransactionStatus: mockSubscribeTransactionStatus,
+    };
+    getSharedWebSocketChannel.mockResolvedValue(mockChannel);
+
+    const onMessage = jest.fn();
+
+    const { result } = renderHook(() =>
+      useWebSocketData({
+        topic: "newHeads",
+        enabled: true,
+        onMessage,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockOn).toHaveBeenCalled();
+    });
+
+    const onCallback = mockOn.mock.calls[0][0];
+
+    await act(async () => {
+      onCallback({ block_number: 1 });
+    });
+    await act(async () => {
+      onCallback({ block_number: 2 });
+    });
+
+    expect(result.current.data).toHaveLength(2);
+    expect(result.current.data[0]).toEqual({ block_number: 2 });
+    expect(result.current.data[1]).toEqual({ block_number: 1 });
+    expect(onMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it("cleans up subscription on unmount", async () => {
+    const mockChannel = {
+      subscribeNewHeads: mockSubscribeNewHeads,
+    };
+    getSharedWebSocketChannel.mockResolvedValue(mockChannel);
+
+    const { unmount } = renderHook(() =>
+      useWebSocketData({
+        topic: "newHeads",
+        enabled: true,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockSubscribeNewHeads).toHaveBeenCalled();
+    });
+
+    unmount();
+
+    expect(mockUnsubscribe).toHaveBeenCalled();
+  });
+
+  it("handles connection error gracefully", async () => {
+    getSharedWebSocketChannel.mockRejectedValue(
+      new Error("Connection refused"),
+    );
+
+    const { result } = renderHook(() =>
+      useWebSocketData({
+        topic: "newHeads",
+        enabled: true,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.status).toBe("error");
+      expect(result.current.error).toBeDefined();
+    });
+  });
+
+  it("does not subscribe when enabled is false", async () => {
+    const mockChannel = {
+      subscribeNewHeads: mockSubscribeNewHeads,
+    };
+    getSharedWebSocketChannel.mockResolvedValue(mockChannel);
+
+    renderHook(() =>
+      useWebSocketData({
+        topic: "newHeads",
+        enabled: false,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockSubscribeNewHeads).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/create-stark-rn/template/rn/hooks/scaffold-stark/useAutoConnect.ts
+++ b/packages/create-stark-rn/template/rn/hooks/scaffold-stark/useAutoConnect.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { useConnect, useAccount } from "@starknet-react/core";
+import { useConnect, useAccount } from "@starknet-start/react";
 import * as SecureStore from "expo-secure-store";
 import scaffoldConfig from "@/scaffold.config";
 
@@ -68,7 +68,7 @@ export const useAutoConnect = (): void => {
   const [isStorageLoaded, setIsStorageLoaded] = useState(false);
 
   const { connect, connectors } = useConnect();
-  const { account } = useAccount();
+  const { isConnected } = useAccount();
 
   const hasAutoConnected = useRef(false);
 
@@ -98,22 +98,22 @@ export const useAutoConnect = (): void => {
     const ttlExpired =
       now - (lastConnectionTime || 0) > scaffoldConfig.autoConnectTTL;
 
-    const connector = connectors.find((c) => c.id === savedConnector?.id);
-    if (!connector || !connector.ready) return;
+    const connector = connectors.find(
+      (c) => c.features["starknet:walletApi"].id === savedConnector?.id,
+    );
+    if (!connector) return;
 
-    const shouldReconnect = !account || ttlExpired;
+    if (ttlExpired || isConnected) return;
 
-    if (shouldReconnect) {
-      hasAutoConnected.current = true;
-      connect({ connector });
-    }
+    hasAutoConnected.current = true;
+    connect({ connector });
   }, [
     isStorageLoaded,
     connect,
     connectors,
     savedConnector,
     lastConnectionTime,
-    account,
+    isConnected,
     wasDisconnectedManually,
   ]);
 };

--- a/packages/create-stark-rn/template/rn/hooks/scaffold-stark/useDeployedContractInfo.ts
+++ b/packages/create-stark-rn/template/rn/hooks/scaffold-stark/useDeployedContractInfo.ts
@@ -5,7 +5,7 @@ import {
   ContractName,
   contracts,
 } from "@/utils/scaffold-stark/contract";
-import { useProvider } from "@starknet-react/core";
+import { useProvider } from "@starknet-start/react";
 import { useEffect, useState } from "react";
 import { BlockIdentifier } from "starknet";
 import { useTargetNetwork } from "./useTargetNetwork";

--- a/packages/create-stark-rn/template/rn/hooks/scaffold-stark/useScaffoldContract.ts
+++ b/packages/create-stark-rn/template/rn/hooks/scaffold-stark/useScaffoldContract.ts
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { Contract, Abi } from "starknet";
-import { useProvider, useAccount } from "@starknet-react/core";
+import { useProvider } from "@starknet-start/react";
 import { useDeployedContractInfo } from "./useDeployedContractInfo";
 import { ContractName } from "@/utils/scaffold-stark/contract";
 
@@ -26,20 +26,15 @@ export const useScaffoldContract = <TContractName extends ContractName>({
     useDeployedContractInfo(contractName);
 
   const { provider: publicClient } = useProvider();
-  const { account } = useAccount();
 
   const contract = useMemo(() => {
     if (!deployedContractData) return undefined;
 
-    const contractInstance = new Contract(
-      deployedContractData.abi as Abi,
-      deployedContractData.address,
-      publicClient,
-    );
-
-    if (account) {
-      contractInstance.connect(account);
-    }
+    const contractInstance = new Contract({
+      abi: deployedContractData.abi as Abi,
+      address: deployedContractData.address,
+      providerOrAccount: publicClient,
+    });
 
     // Wrap the call method to handle response parsing
     const originalCall = contractInstance.call.bind(contractInstance);
@@ -52,7 +47,7 @@ export const useScaffoldContract = <TContractName extends ContractName>({
     };
 
     return contractInstance;
-  }, [deployedContractData, publicClient, account]);
+  }, [deployedContractData, publicClient]);
 
   return {
     data: contract,

--- a/packages/create-stark-rn/template/rn/hooks/scaffold-stark/useScaffoldEventHistory.ts
+++ b/packages/create-stark-rn/template/rn/hooks/scaffold-stark/useScaffoldEventHistory.ts
@@ -9,8 +9,8 @@ import {
   composeEventFilterKeys,
   parseEventData,
 } from "@/utils/scaffold-stark/events";
-import { devnet } from "@starknet-react/chains";
-import { useProvider } from "@starknet-react/core";
+import { devnet } from "@starknet-start/chains";
+import { useProvider } from "@starknet-start/react";
 import {
   Abi,
   ExtractAbiEvent,

--- a/packages/create-stark-rn/template/rn/hooks/scaffold-stark/useScaffoldMultiWriteContract.ts
+++ b/packages/create-stark-rn/template/rn/hooks/scaffold-stark/useScaffoldMultiWriteContract.ts
@@ -7,7 +7,7 @@ import {
   UseScaffoldArgsParam,
   UseScaffoldWriteConfig,
 } from "@/utils/scaffold-stark/contract";
-import { Abi, useNetwork } from "@starknet-react/core";
+import { Abi, useNetwork } from "@starknet-start/react";
 import {
   Call,
   InvocationsDetails,

--- a/packages/create-stark-rn/template/rn/hooks/scaffold-stark/useScaffoldReadContract.ts
+++ b/packages/create-stark-rn/template/rn/hooks/scaffold-stark/useScaffoldReadContract.ts
@@ -5,7 +5,7 @@ import {
   ExtractAbiFunctionNamesScaffold,
   UseScaffoldReadConfig,
 } from "@/utils/scaffold-stark/contract";
-import { Abi, useReadContract } from "@starknet-react/core";
+import { Abi, useReadContract } from "@starknet-start/react";
 import { BlockNumber } from "starknet";
 import { useDeployedContractInfo } from "./useDeployedContractInfo";
 

--- a/packages/create-stark-rn/template/rn/hooks/scaffold-stark/useScaffoldStarkProfile.ts
+++ b/packages/create-stark-rn/template/rn/hooks/scaffold-stark/useScaffoldStarkProfile.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { StarkProfile } from "starknet";
-import * as chains from "@starknet-react/chains";
+import * as chains from "@starknet-start/chains";
 import scaffoldConfig from "@/scaffold.config";
 
 type Network = "mainnet" | "sepolia" | "devnet";

--- a/packages/create-stark-rn/template/rn/hooks/scaffold-stark/useScaffoldStrkBalance.ts
+++ b/packages/create-stark-rn/template/rn/hooks/scaffold-stark/useScaffoldStrkBalance.ts
@@ -1,5 +1,5 @@
-import { Address } from "@starknet-react/chains";
-import { useReadContract } from "@starknet-react/core";
+import { Address } from "@starknet-start/chains";
+import { useReadContract } from "@starknet-start/react";
 import { Abi } from "abi-wan-kanabi";
 import { BlockNumber } from "starknet";
 import { formatUnits } from "@/utils/scaffold-stark/ethUnits";

--- a/packages/create-stark-rn/template/rn/hooks/scaffold-stark/useScaffoldWatchContractEvent.ts
+++ b/packages/create-stark-rn/template/rn/hooks/scaffold-stark/useScaffoldWatchContractEvent.ts
@@ -1,8 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
-import { useProvider } from "@starknet-react/core";
 import { ExtractAbiEventNames } from "abi-wan-kanabi/kanabi";
 import { Abi } from "abi-wan-kanabi/kanabi";
-import { useTargetNetwork } from "./useTargetNetwork";
 import { useScaffoldWebSocketEvents } from "./useScaffoldWebSocketEvents";
 import { useDeployedContractInfo } from "./useDeployedContractInfo";
 import {
@@ -11,7 +9,6 @@ import {
   UseScaffoldWatchContractEventConfig,
 } from "@/utils/scaffold-stark/contract";
 import { resolveEventAbi } from "@/utils/scaffold-stark/events";
-import scaffoldConfig from "@/scaffold.config";
 
 /**
  * Watches for specific contract events and triggers a callback when events are detected.
@@ -37,8 +34,6 @@ export const useScaffoldWatchContractEvent = <
 }: UseScaffoldWatchContractEventConfig<TContractName, TEventName>) => {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | undefined>();
-  const { provider } = useProvider();
-  const { targetNetwork } = useTargetNetwork();
 
   // Validate event existence in ABI
   const { data: deployedContractData, isLoading: deployedContractLoading } =
@@ -89,34 +84,15 @@ export const useScaffoldWatchContractEvent = <
     if (wsError) setError(wsError);
   }, [wsLoading, wsError]);
 
-  // Polling fallback when WebSocket is not available
+  // Log warning when WebSocket is unavailable (no RPC polling fallback yet)
   useEffect(() => {
-    if (!wsError) return;
-
-    let stopped = false;
-    const tick = async () => {
-      try {
-        setIsLoading(true);
-        // Touch provider to maintain dependency
-        void provider;
-      } catch (e: any) {
-        setError(e instanceof Error ? e : new Error(String(e)));
-      } finally {
-        if (!stopped) setIsLoading(false);
-      }
-    };
-
-    const id = setInterval(
-      tick,
-      targetNetwork ? scaffoldConfig.pollingInterval : 4000,
-    );
-
-    return () => {
-      stopped = true;
-      clearInterval(id);
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [wsError, provider, targetNetwork]);
+    if (wsError) {
+      console.warn(
+        `[useScaffoldWatchContractEvent] WebSocket unavailable for ${String(eventName)} on ${contractName}. ` +
+          "Real-time event watching is disabled.",
+      );
+    }
+  }, [wsError, eventName, contractName]);
 
   return { isLoading, error };
 };

--- a/packages/create-stark-rn/template/rn/hooks/scaffold-stark/useScaffoldWriteContract.ts
+++ b/packages/create-stark-rn/template/rn/hooks/scaffold-stark/useScaffoldWriteContract.ts
@@ -4,7 +4,7 @@ import {
   ExtractAbiFunctionNamesScaffold,
   UseScaffoldWriteConfig,
 } from "@/utils/scaffold-stark/contract";
-import { Abi, useNetwork } from "@starknet-react/core";
+import { Abi, useNetwork } from "@starknet-start/react";
 import { useCallback } from "react";
 import { Contract as StarknetJsContract } from "starknet";
 import { useDeployedContractInfo } from "./useDeployedContractInfo";

--- a/packages/create-stark-rn/template/rn/hooks/scaffold-stark/useSwitchNetwork.ts
+++ b/packages/create-stark-rn/template/rn/hooks/scaffold-stark/useSwitchNetwork.ts
@@ -1,4 +1,4 @@
-import { useAccount } from "@starknet-react/core";
+import { useAccount } from "@starknet-start/react";
 import { useGlobalState } from "@/stores/store";
 import scaffoldConfig from "@/scaffold.config";
 import { ChainWithAttributes } from "@/utils/scaffold-stark/network";

--- a/packages/create-stark-rn/template/rn/hooks/scaffold-stark/useTargetNetwork.ts
+++ b/packages/create-stark-rn/template/rn/hooks/scaffold-stark/useTargetNetwork.ts
@@ -1,7 +1,7 @@
 import scaffoldConfig from "@/scaffold.config";
 import { useGlobalState } from "@/stores/store";
 import { type ChainWithAttributes } from "@/utils/scaffold-stark/network";
-import { useAccount } from "@starknet-react/core";
+import { useAccount } from "@starknet-start/react";
 import { useEffect } from "react";
 // import { NETWORKS_EXTRA_DATA } from "@/utils/scaffold-stark";
 

--- a/packages/create-stark-rn/template/rn/hooks/scaffold-stark/useTransactor.ts
+++ b/packages/create-stark-rn/template/rn/hooks/scaffold-stark/useTransactor.ts
@@ -6,7 +6,7 @@ import {
   UseSendTransactionResult,
   useTransactionReceipt,
   UseTransactionReceiptResult,
-} from "@starknet-react/core";
+} from "@starknet-start/react";
 import { useEffect, useState } from "react";
 import {
   AccountInterface,
@@ -35,7 +35,7 @@ interface UseTransactorReturn {
  * transaction state tracking, and block explorer integration. It supports both prepared transactions
  * (using starknet-react's sendTransaction) and direct execution with automatic fee estimation.
  *
- * @param _walletClient - Optional wallet client to use. If not provided, will use the connected account from useAccount
+ * @param _walletClient - Optional wallet client for direct execution path (withSendTransaction=false)
  * @returns {UseTransactorReturn} An object containing:
  *   - writeTransaction: (tx: Call[], withSendTransaction?: boolean) => Promise<string | undefined> - Async function that sends transactions with fee estimation, notifications, and state management
  *   - transactionReceiptInstance: UseTransactionReceiptResult - Transaction receipt data and status from useTransactionReceipt
@@ -45,12 +45,8 @@ interface UseTransactorReturn {
 export const useTransactor = (
   _walletClient?: AccountInterface,
 ): UseTransactorReturn => {
-  let walletClient = _walletClient;
-  const { account } = useAccount();
+  const { status: walletStatus } = useAccount();
   const { targetNetwork } = useTargetNetwork();
-  if (walletClient === undefined && account) {
-    walletClient = account;
-  }
   const sendTransactionInstance = useSendTransaction({});
 
   const [hasActiveToast, setHasActiveToast] = useState<boolean>(false);
@@ -91,9 +87,10 @@ export const useTransactor = (
     withSendTransaction: boolean = true,
   ): Promise<string | undefined> => {
     resetStates();
-    if (!walletClient) {
-      appToast.showError("Cannot access account");
-      console.error("⚡️ ~ file: useTransactor.tsx ~ error");
+
+    if (walletStatus !== "connected") {
+      appToast.showError("Wallet not connected");
+      console.error("⚡️ ~ useTransactor: wallet not connected");
       return;
     }
 
@@ -101,38 +98,35 @@ export const useTransactor = (
       | Awaited<InvokeFunctionResponse>["transaction_hash"]
       | undefined = undefined;
     try {
-      const networkId = await walletClient.getChainId();
       appToast.showPersistentInfo("Awaiting user confirmation", undefined, {
         position: "top",
         useModal: true,
       });
       setHasActiveToast(true);
       if (tx != null && withSendTransaction) {
-        // Tx is already prepared by the caller
+        // Tx is already prepared by the caller — send via wallet request API
         const result = await sendTransactionInstance.sendAsync(tx);
         if (typeof result === "string") {
           transactionHash = result;
         } else {
           transactionHash = result.transaction_hash;
         }
-      } else if (tx != null) {
+      } else if (tx != null && _walletClient) {
+        // Direct execution path — requires an explicit AccountInterface
         try {
-          // First try to estimate fees
-          const estimatedFee = await walletClient.estimateInvokeFee(
+          const estimatedFee = await _walletClient.estimateInvokeFee(
             tx as Call[],
           );
 
-          // Use estimated fee with a safety margin (multiply by 1.5)
           const maxFee =
             (BigInt(estimatedFee.overall_fee) * BigInt(15)) / BigInt(10);
 
-          // Set RPC 0.8 compatible parameters with estimated fees
           const txOptions = {
             version: ETransactionVersion.V3,
             maxFee: "0x" + maxFee.toString(16),
           };
 
-          transactionHash = (await walletClient.execute(tx, txOptions))
+          transactionHash = (await _walletClient.execute(tx, txOptions))
             .transaction_hash;
         } catch (feeEstimationError) {
           console.warn(
@@ -140,12 +134,9 @@ export const useTransactor = (
             feeEstimationError,
           );
 
-          // Fallback to safe default values if estimation fails
           const txOptions = {
             version: ETransactionVersion.V3,
-            // Use a reasonable maxFee value that won't exceed account balance
             maxFee: "0x1000000000",
-            // Set resource bounds for RPC 0.8 compatibility
             resourceBounds: {
               l1_gas: {
                 max_amount: 0x1000000n,
@@ -162,8 +153,16 @@ export const useTransactor = (
             },
           };
 
-          transactionHash = (await walletClient.execute(tx, txOptions))
+          transactionHash = (await _walletClient.execute(tx, txOptions))
             .transaction_hash;
+        }
+      } else if (tx != null) {
+        // withSendTransaction=false but no walletClient provided — fall back to sendAsync
+        const result = await sendTransactionInstance.sendAsync(tx);
+        if (typeof result === "string") {
+          transactionHash = result;
+        } else {
+          transactionHash = result.transaction_hash;
         }
       } else {
         throw new Error("Incorrect transaction passed to transactor");
@@ -175,9 +174,10 @@ export const useTransactor = (
         setHasActiveToast(false);
       }
 
-      const blockExplorerTxURL = networkId
-        ? getBlockExplorerTxLink(targetNetwork.network, transactionHash)
-        : "";
+      const blockExplorerTxURL = getBlockExplorerTxLink(
+        targetNetwork.network,
+        transactionHash,
+      );
       setBlockExplorerTxURL(blockExplorerTxURL);
       appToast.showWaiting(
         "Waiting for transaction to complete",

--- a/packages/create-stark-rn/template/rn/index.js
+++ b/packages/create-stark-rn/template/rn/index.js
@@ -1,0 +1,6 @@
+// Custom entry point — polyfills must run before any module evaluation.
+// Metro evaluates all transitively imported modules before React renders,
+// so placing polyfills in _layout.tsx is too late when other routes import
+// @starknet-start/react at the module level.
+import "./polyfills";
+import "expo-router/entry";

--- a/packages/create-stark-rn/template/rn/package.json
+++ b/packages/create-stark-rn/template/rn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@my-stark-app/rn",
-  "main": "expo-router/entry",
+  "main": "./index.js",
   "version": "1.0.0",
   "overrides": {
     "chalk": "5.3.0",
@@ -18,8 +18,8 @@
     "web": "expo start --web",
     "lint": "expo lint",
     "postinstall": "patch-package",
+    "test": "jest --forceExit",
     "test:watch": "jest --watchAll",
-    "test": "jest",
     "format": "prettier --write ."
   },
   "dependencies": {
@@ -30,9 +30,12 @@
     "@react-navigation/bottom-tabs": "^7.3.10",
     "@react-navigation/elements": "^2.3.8",
     "@react-navigation/native": "^7.1.6",
-    "@scaffold-stark/stark-burner": "^0.1.13",
-    "@starknet-react/chains": "^5.0.1",
-    "@starknet-react/core": "^5.0.1",
+    "@scaffold-stark/stark-burner": "^1.0.0",
+    "@starknet-io/get-starknet-modal": "^5.0.0",
+    "@starknet-start/chains": "^1.0.7",
+    "@starknet-start/explorers": "^1.0.7",
+    "@starknet-start/providers": "^1.0.7",
+    "@starknet-start/react": "^1.0.7",
     "@tanstack/react-query": "^5.87.1",
     "blo": "^2.0.0",
     "expo": "^54.0.0",
@@ -61,15 +64,17 @@
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
     "react-native-svg": "15.12.1",
+    "react-native-vector-icons": "^10.3.0",
     "react-native-web": "^0.21.0",
     "react-native-webview": "13.15.0",
     "react-native-worklets": "^0.5.1",
-    "starknet": "^8.5.3",
+    "starknet": "^9.4.2",
     "toastify-react-native": "^7.2.3",
     "zustand": "^5.0.8"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",
+    "@expo/ngrok": "^4.1.3",
     "@tanstack/eslint-plugin-query": "^5.86.0",
     "@testing-library/react-native": "^13.3.3",
     "@types/jest": "^30.0.0",
@@ -94,8 +99,13 @@
     "moduleNameMapper": {
       "^@/(.*)": "<rootDir>/$1"
     },
+    "transform": {
+      "\\.[jt]sx?$": "babel-jest",
+      "\\.mjs$": "babel-jest"
+    },
     "transformIgnorePatterns": [
-      "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@sentry/react-native|native-base|react-native-svg|@starknet-react/chains)"
+      "/node_modules/(?!(.pnpm|react-native|@react-native|@react-native-community|expo|@expo|@expo-google-fonts|react-navigation|@react-navigation|@sentry/react-native|native-base|react-native-svg|@starknet-start|@scaffold-stark|starknet|viem|abi-wan-kanabi))",
+      "/node_modules/react-native-reanimated/plugin/"
     ]
   },
   "private": true

--- a/packages/create-stark-rn/template/rn/patches/@module-federation+runtime-core+0.12.0.patch
+++ b/packages/create-stark-rn/template/rn/patches/@module-federation+runtime-core+0.12.0.patch
@@ -1,0 +1,36 @@
+diff --git a/node_modules/@module-federation/runtime-core/dist/index.esm.js b/node_modules/@module-federation/runtime-core/dist/index.esm.js
+index 1111111..2222222 100644
+--- a/node_modules/@module-federation/runtime-core/dist/index.esm.js
++++ b/node_modules/@module-federation/runtime-core/dist/index.esm.js
+@@ -1017,7 +1017,12 @@
+                         reject
+                     ]);
+                 } else {
+-                    import(/* webpackIgnore: true */ /* @vite-ignore */ entry).then(resolve).catch(reject);
++                    // PATCHED for Hermes: plain `import(entry)` is an Invalid
++                    // expression for Hermes' parser. This fallback path is the
++                    // dynamic-remote loader; an RN/Expo app bundled by Metro
++                    // never reaches it. Reject explicitly to preserve the
++                    // Promise contract.
++                    reject(new Error('Dynamic remote module loading is not supported in this build'));
+                 }
+             } else {
+                 resolve(remoteEntryExports);
+diff --git a/node_modules/@module-federation/runtime-core/dist/index.cjs.cjs b/node_modules/@module-federation/runtime-core/dist/index.cjs.cjs
+index 1111111..2222222 100644
+--- a/node_modules/@module-federation/runtime-core/dist/index.cjs.cjs
++++ b/node_modules/@module-federation/runtime-core/dist/index.cjs.cjs
+@@ -1018,7 +1018,12 @@
+                         reject
+                     ]);
+                 } else {
+-                    import(/* webpackIgnore: true */ /* @vite-ignore */ entry).then(resolve).catch(reject);
++                    // PATCHED for Hermes: plain `import(entry)` is an Invalid
++                    // expression for Hermes' parser. This fallback path is the
++                    // dynamic-remote loader; an RN/Expo app bundled by Metro
++                    // never reaches it. Reject explicitly to preserve the
++                    // Promise contract.
++                    reject(new Error('Dynamic remote module loading is not supported in this build'));
+                 }
+             } else {
+                 resolve(remoteEntryExports);

--- a/packages/create-stark-rn/template/rn/polyfills.ts
+++ b/packages/create-stark-rn/template/rn/polyfills.ts
@@ -1,0 +1,71 @@
+/**
+ * Polyfills for browser APIs used by @starknet-io/get-starknet-discovery
+ * and @wallet-standard/base that don't exist in React Native / Hermes.
+ *
+ * Must be imported before any starknet packages load.
+ */
+
+const g = globalThis as any;
+
+// Event class polyfill.
+// AppReadyEvent in get-starknet-discovery does `class AppReadyEvent extends Event`
+// and overrides `get type()`. Hermes transpiles class fields as assignments in the
+// constructor, so we must use Object.defineProperty for `type` to allow subclass
+// getter overrides without "Cannot assign to property which has only a getter".
+if (typeof g.Event === "undefined") {
+  g.Event = function Event(
+    this: any,
+    type: string,
+    opts?: { bubbles?: boolean; cancelable?: boolean; composed?: boolean },
+  ) {
+    Object.defineProperty(this, "type", {
+      value: type,
+      writable: true,
+      configurable: true,
+    });
+    this.bubbles = opts?.bubbles ?? false;
+    this.cancelable = opts?.cancelable ?? false;
+    this.composed = opts?.composed ?? false;
+  };
+  g.Event.prototype.preventDefault = function () {};
+  g.Event.prototype.stopPropagation = function () {};
+  g.Event.prototype.stopImmediatePropagation = function () {};
+}
+
+// CustomEvent polyfill
+if (typeof g.CustomEvent === "undefined") {
+  g.CustomEvent = function CustomEvent(this: any, type: string, opts?: any) {
+    g.Event.call(this, type, opts);
+    this.detail = opts?.detail ?? null;
+  };
+  g.CustomEvent.prototype = Object.create(g.Event.prototype);
+  g.CustomEvent.prototype.constructor = g.CustomEvent;
+}
+
+// window.addEventListener / removeEventListener / dispatchEvent polyfill.
+// @starknet-io/get-starknet-discovery calls these during module init
+// for wallet discovery. In React Native `window` exists but lacks
+// DOM EventTarget methods.
+if (typeof g.window !== "undefined" && typeof g.window.addEventListener !== "function") {
+  const listeners: Record<string, Function[]> = {};
+
+  g.window.addEventListener = (type: string, handler: Function) => {
+    if (!listeners[type]) listeners[type] = [];
+    listeners[type].push(handler);
+  };
+
+  g.window.removeEventListener = (type: string, handler: Function) => {
+    if (!listeners[type]) return;
+    listeners[type] = listeners[type].filter((h: Function) => h !== handler);
+  };
+
+  g.window.dispatchEvent = (event: any) => {
+    const handlers = listeners[event?.type];
+    if (handlers) {
+      for (const h of handlers) {
+        try { h(event); } catch (_e) {}
+      }
+    }
+    return true;
+  };
+}

--- a/packages/create-stark-rn/template/rn/scaffold.config.ts
+++ b/packages/create-stark-rn/template/rn/scaffold.config.ts
@@ -1,4 +1,4 @@
-import { Chain } from "@starknet-react/chains";
+import { Chain } from "@starknet-start/chains";
 import { supportedChains as chains } from "./constants/supportedChains";
 
 export type ScaffoldConfig = {

--- a/packages/create-stark-rn/template/rn/services/cavos/connector.ts
+++ b/packages/create-stark-rn/template/rn/services/cavos/connector.ts
@@ -1,56 +1,90 @@
 import aegisConfig from "@/configs/aegisConfig";
 import { AegisSDK } from "@cavos/aegis";
-import {
-  RequestFnCall,
-  RpcMessage,
-  RpcTypeToMessageMap,
-} from "@starknet-io/types-js";
-import { Chain, sepolia } from "@starknet-react/chains";
-import { InjectedConnector, starknetChainId } from "@starknet-react/core";
+import { Permission } from "@starknet-io/types-js";
+import { Chain, sepolia, mainnet, devnet } from "@starknet-start/chains";
+import { starknetChainId } from "@starknet-start/react";
+import type { WalletWithStarknetFeatures } from "@starknet-io/get-starknet-wallet-standard/features";
 import * as SecureStore from "expo-secure-store";
-import { Account, AccountInterface, CallData, RpcProvider } from "starknet";
-
-type ConnectorData = {
-  account: string;
-  chainId: bigint;
-};
-
-type ConnectorIcons = {
-  light: string;
-  dark: string;
-};
+import { Account, CallData, RpcProvider } from "starknet";
 
 export const cavosWalletId = "cavos-wallet";
 export const cavosWalletName = "Cavos Wallet";
 
-const cavosWalletIcon = "https://docs.cavos.xyz/cavos-icon.png";
+const cavosWalletIcon =
+  "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGNpcmNsZSBjeD0iMTIiIGN5PSIxMiIgcj0iMTIiIGZpbGw9IiM2MzY2RjEiLz48L3N2Zz4=" as const;
 
-export class CavosConnector extends InjectedConnector {
-  chain: Chain;
+function chainToWalletStandardChain(chain: Chain): `${string}:${string}` {
+  if (chain.id === mainnet.id) return "starknet:mainnet";
+  if (chain.id === sepolia.id) return "starknet:sepolia";
+  return "starknet:devnet";
+}
+
+/**
+ * Cavos wallet connector implementing the Wallet Standard interface.
+ * Routes transaction execution through the Aegis SDK while conforming
+ * to the WalletWithStarknetFeatures interface expected by @starknet-start/react.
+ */
+export class CavosWallet implements WalletWithStarknetFeatures {
+  readonly version = "1.0.0" as const;
+  readonly name = cavosWalletName;
+  readonly icon = cavosWalletIcon;
+  readonly instanceId = Math.random().toString(36).slice(2);
+
+  private _chain: Chain;
   private _aegisAccount: AegisSDK | null = null;
+  private _connected = false;
+  private _listeners: Record<string, Function[]> = {};
 
   constructor(chain: Chain = sepolia) {
-    super({
-      options: {
-        id: cavosWalletId,
-        name: cavosWalletName,
-        icon: { dark: cavosWalletIcon, light: cavosWalletIcon },
+    this._chain = chain;
+  }
+
+  get chains(): readonly `${string}:${string}`[] {
+    return [chainToWalletStandardChain(this._chain)];
+  }
+
+  get accounts() {
+    if (!this._connected || !this._aegisAccount?.address) return [];
+    return [
+      {
+        address: this._aegisAccount.address,
+        publicKey: new Uint8Array(),
+        chains: [chainToWalletStandardChain(this._chain)] as `${string}:${string}`[],
+        features: [] as never[],
       },
-    });
-    this.chain = chain;
+    ];
   }
 
-  setAegisAccount(aegisAccount: AegisSDK) {
-    this._aegisAccount = aegisAccount;
+  get features(): WalletWithStarknetFeatures["features"] {
+    return {
+      "standard:connect": {
+        version: "1.0.0" as const,
+        connect: this._connect.bind(this),
+      },
+      "standard:disconnect": {
+        version: "1.0.0" as const,
+        disconnect: this._disconnect.bind(this),
+      },
+      "standard:events": {
+        version: "1.0.0" as const,
+        on: this._on.bind(this),
+      },
+      "starknet:walletApi": {
+        id: cavosWalletId,
+        version: "1.0.0" as const,
+        request: this._request.bind(this),
+        walletVersion: "1.0.0",
+      },
+    };
   }
 
-  private async getSdk(): Promise<AegisSDK> {
+  private async _getSdk(): Promise<AegisSDK> {
     if (this._aegisAccount) return this._aegisAccount;
     this._aegisAccount = new AegisSDK(aegisConfig);
     return this._aegisAccount;
   }
 
-  private async deployWithTimeout(sdk: AegisSDK, ms = 90000): Promise<string> {
+  private async _deployWithTimeout(sdk: AegisSDK, ms = 90000): Promise<string> {
     const timeout = new Promise<never>((_, reject) =>
       setTimeout(() => reject(new Error("Cavos deploy timeout")), ms),
     );
@@ -58,138 +92,132 @@ export class CavosConnector extends InjectedConnector {
       const privateKey = await sdk.deployAccount();
       try {
         await sdk.connectAccount(privateKey);
-      } catch (e) {}
+      } catch (_e) {}
       return privateKey;
     })();
     return await Promise.race([deploy, timeout]);
   }
 
-  get id(): string {
-    return cavosWalletId;
-  }
-
-  get name(): string {
-    return cavosWalletName;
-  }
-
-  get icon(): ConnectorIcons {
-    return {
-      dark: cavosWalletIcon,
-      light: cavosWalletIcon,
-    };
-  }
-
-  async account(): Promise<AccountInterface> {
-    if (!this._aegisAccount || !this._aegisAccount.address) {
-      throw new Error("Aegis account not connected");
-    }
-
-    // Create a proxy Account that wraps the Aegis SDK
-    return new Account({
-      provider: new RpcProvider({
-        nodeUrl: this.chain.rpcUrls.public.http[0],
-        chainId: starknetChainId(this.chain.id),
-      }),
-      address: this._aegisAccount.address,
-      // Use a dummy signer - Aegis handles signing internally
-      signer: {
-        getPubKey: async () => "0x0",
-        signTransaction: async () => ["0x0", "0x0"],
-      } as any,
-    });
-  }
-
-  available(): boolean {
-    return true;
-  }
-
-  async ready(): Promise<boolean> {
-    return this._aegisAccount !== null && !!this._aegisAccount.address;
-  }
-
-  chainId(): Promise<bigint> {
-    return Promise.resolve(this.chain.id);
-  }
-
-  async request<T extends RpcMessage["type"]>(
-    call: RequestFnCall<T>,
-  ): Promise<RpcTypeToMessageMap[T]["result"]> {
-    if (!this._aegisAccount) {
-      throw new Error("Aegis account not connected");
-    }
-
-    if (call.params && "calls" in call.params) {
-      const compiledCalls = call.params.calls.map((element: any) => ({
-        contractAddress: element.contract_address || element.contractAddress,
-        entrypoint: element.entry_point || element.entrypoint,
-        calldata: Array.isArray(element.calldata)
-          ? element.calldata
-          : CallData.compile(element.calldata),
-      }));
-
+  private _connect = async ({ silent = false } = {}) => {
+    if (!this._aegisAccount?.address) {
       try {
-        let result: any;
-        if (compiledCalls.length === 1) {
-          const c = compiledCalls[0];
-          result = await this._aegisAccount.execute(
-            c.contractAddress,
-            c.entrypoint,
-            c.calldata,
-          );
-        } else {
-          result = await this._aegisAccount.executeBatch(compiledCalls);
-        }
-        // Adapt Aegis result to expected RPC shape
-        return { transaction_hash: result.transactionHash } as any;
-      } catch (e) {
-        console.error("Cavos transaction failed:", e);
-        throw e;
-      }
-    }
-
-    return await super.request(call);
-  }
-
-  async connect(): Promise<ConnectorData> {
-    if (!this._aegisAccount || !this._aegisAccount.address) {
-      try {
-        const sdk = await this.getSdk();
+        const sdk = await this._getSdk();
         const savedKey = await SecureStore.getItemAsync("cavos_wallet_key");
         if (savedKey) {
           await sdk.connectAccount(savedKey);
           this._aegisAccount = sdk;
         } else {
-          const privateKey = await this.deployWithTimeout(sdk, 90000);
+          const privateKey = await this._deployWithTimeout(sdk, 90000);
           await SecureStore.setItemAsync("cavos_wallet_key", privateKey);
           this._aegisAccount = sdk;
         }
       } catch (e) {
-        console.error("[CavosConnector] connect() error:", e);
+        console.error("[CavosWallet] connect() error:", e);
         throw e;
       }
     }
 
     if (!this._aegisAccount?.address) {
-      console.error(
-        "[CavosConnector] connect() failed: aegisAccount has no address",
-      );
       throw new Error("Failed to connect Cavos wallet");
     }
 
-    return {
-      account: this._aegisAccount.address,
-      chainId: this.chain.id,
-    };
-  }
+    this._connected = true;
+    this._emit("change", { accounts: this.accounts });
+    return { accounts: this.accounts };
+  };
 
-  disconnect(): Promise<void> {
+  private _disconnect = async () => {
     try {
       if (this._aegisAccount) {
         this._aegisAccount.disconnect();
       }
     } finally {
       this._aegisAccount = null;
+      this._connected = false;
     }
-    return Promise.resolve();
+    this._emit("change", { accounts: [] });
+  };
+
+  private _on = (event: string, listener: Function) => {
+    if (!this._listeners[event]) this._listeners[event] = [];
+    this._listeners[event].push(listener);
+    return () => this._off(event, listener);
+  };
+
+  private _off(event: string, listener: Function) {
+    const listeners = this._listeners[event];
+    if (!listeners) return;
+    this._listeners[event] = listeners.filter((l) => l !== listener);
   }
+
+  private _emit(event: string, ...args: any[]) {
+    const listeners = this._listeners[event];
+    if (!listeners) return;
+    for (const listener of listeners) listener.apply(null, args);
+  }
+
+  private _request = async (call: { type: string; params?: any }): Promise<any> => {
+    const { type, params } = call;
+
+    switch (type) {
+      case "wallet_requestChainId":
+        return `0x${this._chain.id.toString(16)}`;
+
+      case "wallet_getPermissions":
+        return this._connected ? [Permission.ACCOUNTS] : [];
+
+      case "wallet_requestAccounts":
+        return this._aegisAccount?.address ? [this._aegisAccount.address] : [];
+
+      case "wallet_addStarknetChain":
+        return true;
+
+      case "wallet_watchAsset":
+        return true;
+
+      case "wallet_switchStarknetChain": {
+        if (!params) throw new Error("Params are missing");
+        return true;
+      }
+
+      case "wallet_addInvokeTransaction": {
+        if (!params) throw new Error("Params are missing");
+        if (!this._aegisAccount) throw new Error("Aegis account not connected");
+
+        const { calls } = params;
+        const compiledCalls = calls.map((element: any) => ({
+          contractAddress: element.contract_address || element.contractAddress,
+          entrypoint: element.entry_point || element.entrypoint,
+          calldata: Array.isArray(element.calldata)
+            ? element.calldata
+            : CallData.compile(element.calldata),
+        }));
+
+        try {
+          let result: any;
+          if (compiledCalls.length === 1) {
+            const c = compiledCalls[0];
+            result = await this._aegisAccount.execute(
+              c.contractAddress,
+              c.entrypoint,
+              c.calldata,
+            );
+          } else {
+            result = await this._aegisAccount.executeBatch(compiledCalls);
+          }
+          return { transaction_hash: result.transactionHash };
+        } catch (e) {
+          console.error("[CavosWallet] transaction failed:", e);
+          throw e;
+        }
+      }
+
+      case "wallet_signTypedData": {
+        throw new Error("CavosWallet does not support signTypedData");
+      }
+
+      default:
+        throw new Error(`Unknown request type: ${type}`);
+    }
+  };
 }

--- a/packages/create-stark-rn/template/rn/services/web3/websocket.ts
+++ b/packages/create-stark-rn/template/rn/services/web3/websocket.ts
@@ -1,4 +1,4 @@
-import { Chain } from "@starknet-react/chains";
+import { Chain } from "@starknet-start/chains";
 import { WebSocketChannel } from "starknet";
 import scaffoldConfig from "@/scaffold.config";
 
@@ -42,12 +42,12 @@ export const getWsUrlForChain = (chain: Chain): string => {
     case "sepolia":
       return httpToWs(
         chain.rpcUrls.public.http[0] ||
-          "https://starknet-sepolia.public.blastapi.io/rpc/v0_9",
+          "https://starknet-sepolia.public.blastapi.io/rpc/v0_10",
       );
     case "mainnet":
       return httpToWs(
         chain.rpcUrls.public.http[0] ||
-          "https://starknet-mainnet.public.blastapi.io/rpc/v0_9",
+          "https://starknet-mainnet.public.blastapi.io/rpc/v0_10",
       );
     default:
       return httpToWs(chain.rpcUrls.public.http[0] || "");

--- a/packages/create-stark-rn/template/rn/tsconfig.json
+++ b/packages/create-stark-rn/template/rn/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
     "strict": true,
+    "skipLibCheck": true,
     "paths": {
       "@/*": ["./*"]
     }

--- a/packages/create-stark-rn/template/rn/utils/scaffold-stark/__tests__/contract.test.ts
+++ b/packages/create-stark-rn/template/rn/utils/scaffold-stark/__tests__/contract.test.ts
@@ -18,6 +18,14 @@ describe("contract utils", () => {
     expect((merged as any).onlyExternal.k).toBe(9);
   });
 
+  test("deepMergeContracts uses local value when external is undefined", () => {
+    const local = { a: 1, b: 2 } as any;
+    const external = {} as any;
+    const merged = deepMergeContracts(local, external);
+    expect(merged.a).toBe(1);
+    expect(merged.b).toBe(2);
+  });
+
   test("getFunctionsByStateMutability extracts interface functions", () => {
     const abi: any = [
       {
@@ -47,15 +55,428 @@ describe("contract utils", () => {
     expect(writes.map((f) => f.name)).toEqual(["write"]);
   });
 
+  test("getFunctionsByStateMutability extracts top-level functions", () => {
+    const abi: any = [
+      {
+        type: "function",
+        name: "topLevel",
+        state_mutability: "view",
+        inputs: [],
+        outputs: [],
+      },
+    ];
+    const result = getFunctionsByStateMutability(abi, "view");
+    expect(result.map((f) => f.name)).toEqual(["topLevel"]);
+  });
+
+  test("getFunctionsByStateMutability filters non-function interface items", () => {
+    const abi: any = [
+      {
+        type: "interface",
+        name: "I",
+        items: [
+          { type: "event", name: "SomeEvent" },
+          {
+            type: "function",
+            name: "fn1",
+            state_mutability: "view",
+            inputs: [],
+            outputs: [],
+          },
+        ],
+      },
+    ];
+    const result = getFunctionsByStateMutability(abi, "view");
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("fn1");
+  });
+
   test("parseTuple splits top-level tuple values respecting nesting", () => {
     expect(parseTuple("(a,b)")).toEqual(["a", "b"]);
     expect(parseTuple("(a,(b,c),d)")).toEqual(["a", "(b,c)", "d"]);
   });
 
+  test("parseTuple handles deeply nested tuples", () => {
+    expect(parseTuple("(a,((b,c),d))")).toEqual(["a", "((b,c),d)"]);
+  });
+
+  test("parseTuple handles single element", () => {
+    expect(parseTuple("(a)")).toEqual(["a"]);
+  });
+
+  // --- parseParamWithType DECODE (isRead=true) tests ---
+
   test("parseParamWithType decodes felts and bools for reads", () => {
     expect(parseParamWithType("core::felt252", 255n as any, true)).toBe("0xff");
     expect(parseParamWithType("core::bool", "0x1" as any, true)).toBe("true");
   });
+
+  test("parseParamWithType decodes bool false", () => {
+    expect(parseParamWithType("core::bool", "0x0" as any, true)).toBe("false");
+    expect(parseParamWithType("core::bool", true as any, true)).toBe(true);
+  });
+
+  test("parseParamWithType decodes integer types", () => {
+    const result = parseParamWithType("core::integer::u8", 42n as any, true);
+    expect(result).toBe(42);
+  });
+
+  test("parseParamWithType decodes hex integer", () => {
+    const result = parseParamWithType("core::integer::u16", "0x0a" as any, true);
+    expect(result).toBe(10);
+  });
+
+  test("parseParamWithType decodes bigint types", () => {
+    const result = parseParamWithType("core::integer::u256", 123n as any, true);
+    expect(typeof result === "bigint" || typeof result === "object").toBe(true);
+  });
+
+  test("parseParamWithType decodes bytes31", () => {
+    const result = parseParamWithType("core::bytes_31::bytes31", 255n as any, true);
+    expect(result).toBe("0xff");
+  });
+
+  test("parseParamWithType decodes contract address", () => {
+    const result = parseParamWithType(
+      "core::starknet::contract_address::ContractAddress",
+      "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+      true,
+    );
+    expect(typeof result).toBe("string");
+    expect(result).toMatch(/^0x/);
+  });
+
+  test("parseParamWithType decodes tuple for reads", () => {
+    const result = parseParamWithType(
+      "(core::felt252,core::felt252)",
+      { 0: 1n, 1: 2n } as any,
+      true,
+    );
+    expect(result).toContain("0x1");
+    expect(result).toContain("0x2");
+  });
+
+  test("parseParamWithType decodes array for reads", () => {
+    const result = parseParamWithType(
+      "core::array::Array::<core::felt252>",
+      [1n, 2n] as any,
+      true,
+    );
+    expect(Array.isArray(result)).toBe(true);
+  });
+
+  test("parseParamWithType decodes CairoOption None for reads", () => {
+    const { CairoOption, CairoOptionVariant } = require("starknet");
+    const noneOpt = new CairoOption(CairoOptionVariant.None);
+    const result = parseParamWithType(
+      "core::option::Option::<core::felt252>",
+      noneOpt,
+      true,
+    );
+    expect(result).toBe("None");
+  });
+
+  test("parseParamWithType decodes CairoOption Some for reads", () => {
+    const { CairoOption, CairoOptionVariant } = require("starknet");
+    const someOpt = new CairoOption(CairoOptionVariant.Some, 42n);
+    const result = parseParamWithType(
+      "core::option::Option::<core::felt252>",
+      someOpt,
+      true,
+    );
+    expect(typeof result).toBe("string");
+    expect(result).toContain("Some");
+  });
+
+  test("parseParamWithType decodes CairoResult Ok for reads", () => {
+    const { CairoResult, CairoResultVariant } = require("starknet");
+    const okResult = new CairoResult(CairoResultVariant.Ok, 10n);
+    const result = parseParamWithType(
+      "core::result::Result::<core::felt252,core::felt252>",
+      okResult,
+      true,
+    );
+    expect(typeof result).toBe("string");
+    expect(result).toContain("Ok");
+  });
+
+  test("parseParamWithType decodes CairoResult Err for reads", () => {
+    const { CairoResult, CairoResultVariant } = require("starknet");
+    const errResult = new CairoResult(CairoResultVariant.Err, 99n);
+    const result = parseParamWithType(
+      "core::result::Result::<core::felt252,core::felt252>",
+      errResult,
+      true,
+    );
+    expect(typeof result).toBe("string");
+    expect(result).toContain("Err");
+  });
+
+  test("parseParamWithType decodes byte array for reads", () => {
+    const { byteArray } = require("starknet");
+    const ba = byteArray.byteArrayFromString("hello");
+    const result = parseParamWithType(
+      "core::byte_array::ByteArray",
+      ba,
+      true,
+    );
+    expect(result).toBe("hello");
+  });
+
+  test("parseParamWithType passes through unknown types for reads", () => {
+    const input = { custom: "data" };
+    const result = parseParamWithType("some::unknown::Type", input, true);
+    expect(result).toEqual(input);
+  });
+
+  // --- parseParamWithType ENCODE (isRead=false) tests ---
+
+  test("parseParamWithType encodes felt for writes", () => {
+    const result = parseParamWithType("core::felt252", "0x123", false);
+    expect(result).toBe("0x123");
+  });
+
+  test("parseParamWithType encodes bool for writes", () => {
+    expect(parseParamWithType("core::bool", "false", false)).toBe("0x0");
+    expect(parseParamWithType("core::bool", "true", false)).toBe("0x1");
+  });
+
+  test("parseParamWithType encodes u256 for writes", () => {
+    const result = parseParamWithType("core::integer::u256", "100", false);
+    expect(result).toBeDefined();
+  });
+
+  test("parseParamWithType encodes byte array for writes", () => {
+    const result = parseParamWithType("core::byte_array::ByteArray", "hello", false);
+    expect(result).toBeDefined();
+  });
+
+  test("parseParamWithType encodes byte array for read args parsing", () => {
+    const result = parseParamWithType(
+      "core::byte_array::ByteArray",
+      "hello",
+      false,
+      true,
+    );
+    expect(result).toBe("hello");
+  });
+
+  test("parseParamWithType encodes contract address for writes", () => {
+    const result = parseParamWithType(
+      "core::starknet::contract_address::ContractAddress",
+      "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+      false,
+    );
+    expect(result).toBeDefined();
+  });
+
+  test("parseParamWithType encodes CairoOption None for writes", () => {
+    const result = parseParamWithType(
+      "core::option::Option::<core::felt252>",
+      "None",
+      false,
+    );
+    expect(result).toBeDefined();
+  });
+
+  test("parseParamWithType encodes CairoOption Some for writes", () => {
+    const result = parseParamWithType(
+      "core::option::Option::<core::felt252>",
+      "Some(0x123)",
+      false,
+    );
+    expect(result).toBeDefined();
+  });
+
+  test("parseParamWithType encodes array from string for writes", () => {
+    const result = parseParamWithType(
+      "core::array::Array::<core::felt252>",
+      "0x1, 0x2, 0x3",
+      false,
+    );
+    expect(Array.isArray(result)).toBe(true);
+  });
+
+  test("parseParamWithType encodes array from array for writes", () => {
+    const result = parseParamWithType(
+      "core::array::Array::<core::felt252>",
+      ["0x1", "0x2"],
+      false,
+    );
+    expect(Array.isArray(result)).toBe(true);
+  });
+
+  test("parseParamWithType encodes array for read args parsing", () => {
+    const result = parseParamWithType(
+      "core::array::Array::<core::felt252>",
+      "0x1, 0x2",
+      false,
+      true,
+    );
+    expect(Array.isArray(result)).toBe(true);
+  });
+
+  test("parseParamWithType encodes array from array for read args parsing", () => {
+    const result = parseParamWithType(
+      "core::array::Array::<core::felt252>",
+      ["0x1", "0x2"],
+      false,
+      true,
+    );
+    expect(Array.isArray(result)).toBe(true);
+  });
+
+  test("parseParamWithType encodes array with no generic type returns param", () => {
+    const result = parseParamWithType(
+      "core::array::Array::<>",
+      "0x1, 0x2",
+      false,
+    );
+    // When genericType is empty/falsy, returns param as-is
+    expect(result).toBe("0x1, 0x2");
+  });
+
+  test("parseParamWithType encodes tuple for writes", () => {
+    const result = parseParamWithType(
+      "(core::felt252,core::felt252)",
+      "(0x1,0x2)",
+      false,
+    );
+    expect(result).toBeDefined();
+  });
+
+  test("parseParamWithType encodes struct object for read args parsing", () => {
+    const result = parseParamWithType(
+      "some::custom::Struct",
+      {
+        field1: { type: "core::felt252", value: "0x1" },
+        field2: { type: "core::felt252", value: "0x2" },
+      },
+      false,
+      true,
+    );
+    expect(typeof result).toBe("object");
+    expect(result.field1).toBe("0x1");
+  });
+
+  test("parseParamWithType encodes struct object for raw args", () => {
+    const result = parseParamWithType(
+      "some::custom::Struct",
+      {
+        field1: { type: "core::felt252", value: "0x1" },
+        field2: { type: "core::felt252", value: "0x2" },
+      },
+      false,
+      false,
+    );
+    expect(Array.isArray(result)).toBe(true);
+  });
+
+  test("parseParamWithType handles struct with array fields for raw args", () => {
+    const result = parseParamWithType(
+      "some::custom::Struct",
+      {
+        field1: { type: "core::array::Array::<core::felt252>", value: ["0x1", "0x2"] },
+      },
+      false,
+      false,
+    );
+    expect(Array.isArray(result)).toBe(true);
+  });
+
+  test("parseParamWithType skips empty/undefined struct values for read args", () => {
+    const result = parseParamWithType(
+      "some::custom::Struct",
+      {
+        field1: { type: "core::felt252", value: "" },
+        field2: { type: "core::felt252", value: "0x1" },
+      },
+      false,
+      true,
+    );
+    expect(result.field1).toBeUndefined();
+    expect(result.field2).toBe("0x1");
+  });
+
+  test("parseParamWithType handles encode error gracefully", () => {
+    const result = parseParamWithType(
+      "some::custom::Struct",
+      null,
+      false,
+      false,
+    );
+    // Should return param on error
+    expect(result).toBeNull();
+  });
+
+  test("parseParamWithType handles CairoResult encode for writes", () => {
+    const result = parseParamWithType(
+      "core::result::Result::<core::felt252,core::felt252>",
+      {
+        variant: {
+          Ok: { value: "0x1", type: "core::felt252" },
+          Err: { value: undefined, type: "core::felt252" },
+        },
+      },
+      false,
+    );
+    expect(result).toBeDefined();
+  });
+
+  test("parseParamWithType handles CairoResult Err encode for writes", () => {
+    const result = parseParamWithType(
+      "core::result::Result::<core::felt252,core::felt252>",
+      {
+        variant: {
+          Ok: { value: undefined, type: "core::felt252" },
+          Err: { value: "0x1", type: "core::felt252" },
+        },
+      },
+      false,
+    );
+    expect(result).toBeDefined();
+  });
+
+  test("parseParamWithType handles custom enum encode for writes", () => {
+    const result = parseParamWithType(
+      "some::custom::Enum",
+      {
+        variant: {
+          VariantA: { value: "0x1", type: "core::felt252" },
+          VariantB: { value: "", type: "core::felt252" },
+        },
+      },
+      false,
+      false,
+    );
+    expect(result).toBeDefined();
+  });
+
+  test("parseParamWithType handles custom enum encode for read args parsing", () => {
+    const result = parseParamWithType(
+      "some::custom::Enum",
+      {
+        variant: {
+          VariantA: { value: "0x1", type: "core::felt252" },
+          VariantB: { value: undefined, type: "core::felt252" },
+        },
+      },
+      false,
+      true,
+    );
+    expect(result).toBeDefined();
+  });
+
+  test("parseParamWithType returns param for non-object fallback encode", () => {
+    const result = parseParamWithType(
+      "core::array::Array::<core::felt252>",
+      123,
+      false,
+    );
+    expect(result).toBe(123);
+  });
+
+  // --- ContractClassHashCache tests ---
 
   test("ContractClassHashCache caches and dedupes requests", async () => {
     const cache = ContractClassHashCache.getInstance();
@@ -75,5 +496,47 @@ describe("contract utils", () => {
     const r3 = await cache.getClassHash(client, "0xaddr", "pending");
     expect(r3).toBe("0xabc");
     expect(getClassHashAt).toHaveBeenCalledTimes(1);
+  });
+
+  test("ContractClassHashCache returns undefined on error", async () => {
+    const cache = ContractClassHashCache.getInstance();
+    cache.clear();
+    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation();
+    const client: any = {
+      getClassHashAt: jest.fn().mockRejectedValue(new Error("network error")),
+    };
+    const result = await cache.getClassHash(client, "0xfail", "pending");
+    expect(result).toBeUndefined();
+    consoleErrorSpy.mockRestore();
+  });
+
+  test("ContractClassHashCache uses default block identifier", async () => {
+    const cache = ContractClassHashCache.getInstance();
+    cache.clear();
+    const client: any = {
+      getClassHashAt: jest.fn().mockResolvedValue("0xdef"),
+    };
+    const result = await cache.getClassHash(client, "0xaddr2");
+    expect(result).toBe("0xdef");
+    expect(client.getClassHashAt).toHaveBeenCalledWith(
+      "0xaddr2",
+      "pre_confirmed",
+    );
+  });
+
+  test("ContractClassHashCache different keys are cached separately", async () => {
+    const cache = ContractClassHashCache.getInstance();
+    cache.clear();
+    const client: any = {
+      getClassHashAt: jest
+        .fn()
+        .mockResolvedValueOnce("0xaaa")
+        .mockResolvedValueOnce("0xbbb"),
+    };
+    const r1 = await cache.getClassHash(client, "0xaddr1", "pending");
+    const r2 = await cache.getClassHash(client, "0xaddr2", "pending");
+    expect(r1).toBe("0xaaa");
+    expect(r2).toBe("0xbbb");
+    expect(client.getClassHashAt).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/create-stark-rn/template/rn/utils/scaffold-stark/__tests__/events.test.ts
+++ b/packages/create-stark-rn/template/rn/utils/scaffold-stark/__tests__/events.test.ts
@@ -1,6 +1,11 @@
 import {
+  buildEventKeys,
   composeEventFilterKeys,
+  enrichLog,
+  getLatestAcceptedBlockNumber,
   parseEventData,
+  parseLogsArgs,
+  resolveEventAbi,
   serializeEventKey,
 } from "@/utils/scaffold-stark/events";
 import type { Abi } from "starknet";
@@ -9,18 +14,219 @@ import type { Abi } from "starknet";
 const abi: Abi = [{ type: "interface", name: "I", items: [] }];
 
 describe("events utils", () => {
+  // --- resolveEventAbi ---
+
+  test("resolveEventAbi returns undefined for undefined abi", () => {
+    const result = resolveEventAbi(undefined, "Transfer");
+    expect(result).toBeUndefined();
+  });
+
+  test("resolveEventAbi returns undefined when no event matches", () => {
+    const testAbi: any = [
+      { type: "event", name: "pkg::Transfer", kind: "struct", members: [] },
+    ];
+    const result = resolveEventAbi(testAbi, "Approval");
+    expect(result).toBeUndefined();
+  });
+
+  test("resolveEventAbi returns event when exactly one matches", () => {
+    const testAbi: any = [
+      { type: "event", name: "pkg::Transfer", kind: "struct", members: [] },
+    ];
+    const result = resolveEventAbi(testAbi, "Transfer");
+    expect(result).toBeDefined();
+    expect((result as any).name).toBe("pkg::Transfer");
+  });
+
+  test("resolveEventAbi throws when multiple events match", () => {
+    const testAbi: any = [
+      { type: "event", name: "a::Transfer", kind: "struct", members: [] },
+      { type: "event", name: "b::Transfer", kind: "struct", members: [] },
+    ];
+    expect(() => resolveEventAbi(testAbi, "Transfer")).toThrow("Ambiguous");
+  });
+
+  // --- parseLogsArgs ---
+
+  test("parseLogsArgs returns empty object when no events parsed", () => {
+    const testAbi: any = [
+      { type: "interface", name: "I", items: [] },
+    ];
+    const result = parseLogsArgs(testAbi, "pkg::Event", []);
+    expect(result).toEqual({});
+  });
+
+  // --- enrichLog ---
+
+  test("enrichLog fetches block, transaction, and receipt", async () => {
+    const mockClient: any = {
+      getBlockWithTxHashes: jest.fn().mockResolvedValue({ block_number: 1 }),
+      getTransactionByHash: jest.fn().mockResolvedValue({ hash: "0x1" }),
+      getTransactionReceipt: jest.fn().mockResolvedValue({ status: "ok" }),
+    };
+    const log = { block_hash: "0xblock", transaction_hash: "0xtx" };
+    const result = await enrichLog(mockClient, log, {
+      block: true,
+      transaction: true,
+      receipt: true,
+    });
+    expect(result.block).toEqual({ block_number: 1 });
+    expect(result.transaction).toEqual({ hash: "0x1" });
+    expect(result.receipt).toEqual({ status: "ok" });
+  });
+
+  test("enrichLog skips fetches when opts are false", async () => {
+    const mockClient: any = {
+      getBlockWithTxHashes: jest.fn(),
+      getTransactionByHash: jest.fn(),
+      getTransactionReceipt: jest.fn(),
+    };
+    const log = { block_hash: "0xblock", transaction_hash: "0xtx" };
+    const result = await enrichLog(mockClient, log, {
+      block: false,
+      transaction: false,
+      receipt: false,
+    });
+    expect(result.block).toBeNull();
+    expect(result.transaction).toBeNull();
+    expect(result.receipt).toBeNull();
+    expect(mockClient.getBlockWithTxHashes).not.toHaveBeenCalled();
+  });
+
+  test("enrichLog skips fetches when hashes are null", async () => {
+    const mockClient: any = {
+      getBlockWithTxHashes: jest.fn(),
+      getTransactionByHash: jest.fn(),
+      getTransactionReceipt: jest.fn(),
+    };
+    const log = { block_hash: null, transaction_hash: null };
+    const result = await enrichLog(mockClient, log, {
+      block: true,
+      transaction: true,
+      receipt: true,
+    });
+    expect(result.block).toBeNull();
+    expect(result.transaction).toBeNull();
+    expect(result.receipt).toBeNull();
+  });
+
+  // --- getLatestAcceptedBlockNumber ---
+
+  test("getLatestAcceptedBlockNumber returns bigint block number", async () => {
+    const mockClient: any = {
+      getBlockLatestAccepted: jest.fn().mockResolvedValue({ block_number: 42 }),
+    };
+    const result = await getLatestAcceptedBlockNumber(mockClient);
+    expect(result).toBe(42n);
+  });
+
+  // --- buildEventKeys ---
+
+  test("buildEventKeys returns selector key without filters", () => {
+    const keys = buildEventKeys("Transfer", undefined, {} as any, abi);
+    expect(keys.length).toBe(1);
+    expect(keys[0].length).toBe(1);
+    expect(keys[0][0]).toMatch(/^0x/);
+  });
+
+  test("buildEventKeys concatenates filter keys", () => {
+    // Mock composeEventFilterKeys to return additional keys
+    const eventAbi: any = { members: [] };
+    const keys = buildEventKeys("Transfer", {}, eventAbi, abi);
+    expect(keys.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("buildEventKeys limits to maxKeys", () => {
+    const keys = buildEventKeys("Transfer", undefined, {} as any, abi, 1);
+    expect(keys.length).toBeLessThanOrEqual(1);
+  });
+
+  // --- serializeEventKey ---
+
   test("serializeEventKey handles byte array", () => {
     const abiEntry = { type: "core::byte_array::ByteArray", name: "k" } as any;
-    const result = serializeEventKey("hello", abiEntry, {} as any, {} as any);
+    const result = serializeEventKey("hello", abiEntry, {} as any, {} as any, abi);
     expect(Array.isArray(result)).toBe(true);
     expect(result[0]).toMatch(/^0x/);
   });
+
+  test("serializeEventKey handles felt252 type", () => {
+    const abiEntry = { type: "core::felt252", name: "k" } as any;
+    const result = serializeEventKey("123", abiEntry, {} as any, {} as any, abi);
+    expect(Array.isArray(result)).toBe(true);
+    expect(result.length).toBeGreaterThanOrEqual(1);
+  });
+
+  // --- composeEventFilterKeys ---
 
   test("composeEventFilterKeys returns empty for non-keyed events", () => {
     const event: any = { members: [] };
     const keys = composeEventFilterKeys({}, event, abi);
     expect(Array.isArray(keys)).toBe(true);
   });
+
+  test("composeEventFilterKeys returns empty when event has no members property", () => {
+    const event: any = {};
+    const keys = composeEventFilterKeys({}, event, abi);
+    expect(keys).toEqual([]);
+  });
+
+  test("composeEventFilterKeys serializes key members with values", () => {
+    const event: any = {
+      members: [
+        { name: "from", type: "core::felt252", kind: "key" },
+      ],
+    };
+    const keys = composeEventFilterKeys({ from: "123" }, event, abi);
+    expect(keys.length).toBeGreaterThan(0);
+  });
+
+  test("composeEventFilterKeys handles key members without values using certainLengthTypeMap", () => {
+    const event: any = {
+      members: [
+        { name: "from", type: "core::felt252", kind: "key" },
+        { name: "to", type: "core::felt252", kind: "key" },
+      ],
+    };
+    // "from" has no value in input, "core::felt252" is in certainLengthTypeMap
+    const keys = composeEventFilterKeys({}, event, abi);
+    expect(keys.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("composeEventFilterKeys breaks on unknown type without value", () => {
+    const event: any = {
+      members: [
+        { name: "data", type: "some::unknown::Type", kind: "key" },
+        { name: "from", type: "core::felt252", kind: "key" },
+      ],
+    };
+    // Should break on "data" since it has no value and unknown type
+    const keys = composeEventFilterKeys({}, event, abi);
+    expect(keys).toEqual([]);
+  });
+
+  test("composeEventFilterKeys handles array filter values", () => {
+    const event: any = {
+      members: [
+        { name: "from", type: "core::felt252", kind: "key" },
+      ],
+    };
+    const keys = composeEventFilterKeys({ from: ["123", "456"] }, event, abi);
+    expect(keys.length).toBeGreaterThan(0);
+  });
+
+  test("composeEventFilterKeys skips data kind members", () => {
+    const event: any = {
+      members: [
+        { name: "amount", type: "core::integer::u256", kind: "data" },
+        { name: "from", type: "core::felt252", kind: "key" },
+      ],
+    };
+    const keys = composeEventFilterKeys({ from: "123" }, event, abi);
+    expect(keys.length).toBeGreaterThan(0);
+  });
+
+  // --- parseEventData ---
 
   test("parseEventData converts contract addresses in fields and arrays", () => {
     const args = { addr: 0x123n, arr: [0x456n] } as any;
@@ -39,5 +245,38 @@ describe("events utils", () => {
     const parsed = parseEventData(args, types);
     expect(parsed.addr).toMatch(/^0x/);
     expect(parsed.arr[0]).toMatch(/^0x/);
+  });
+
+  test("parseEventData handles tuple with contract address", () => {
+    const args = {
+      pair: { 0: 0x123n, 1: 42n },
+    } as any;
+    const types = [
+      {
+        name: "pair",
+        type: "(core::starknet::contract_address::ContractAddress,core::integer::u256)",
+        kind: "data",
+      },
+    ];
+    const parsed = parseEventData(args, types);
+    expect(parsed.pair[0]).toMatch(/^0x/);
+    // non-address tuple member stays as-is
+    expect(parsed.pair[1]).toBe(42n);
+  });
+
+  test("parseEventData returns value as-is for unknown types", () => {
+    const args = { val: 42n } as any;
+    const types = [
+      { name: "val", type: "core::integer::u256", kind: "data" },
+    ];
+    const parsed = parseEventData(args, types);
+    expect(parsed.val).toBe(42n);
+  });
+
+  test("parseEventData returns value as-is when type not found", () => {
+    const args = { unknown: "hello" } as any;
+    const types: any[] = [];
+    const parsed = parseEventData(args, types);
+    expect(parsed.unknown).toBe("hello");
   });
 });

--- a/packages/create-stark-rn/template/rn/utils/scaffold-stark/__tests__/network.test.ts
+++ b/packages/create-stark-rn/template/rn/utils/scaffold-stark/__tests__/network.test.ts
@@ -4,6 +4,8 @@ import {
   getBlockExplorerClasshashLink,
   getBlockExplorerLink,
   getBlockExplorerTxLink,
+  getTargetNetworks,
+  NETWORKS_EXTRA_DATA,
 } from "@/utils/scaffold-stark/network";
 
 describe("network utils", () => {
@@ -16,9 +18,31 @@ describe("network utils", () => {
     expect(url).toContain("/tx/0xabc");
   });
 
+  test("getBlockExplorerTxLink returns url for mainnet", () => {
+    const url = getBlockExplorerTxLink(chains.mainnet.network, "0xdef");
+    expect(url).toContain("/tx/0xdef");
+  });
+
+  test("getBlockExplorerTxLink returns url for devnet", () => {
+    const url = getBlockExplorerTxLink(chains.devnet.network, "0x123");
+    // devnet may not have explorers, should fallback to starkscan
+    expect(url).toContain("/tx/0x123");
+  });
+
   test("getBlockExplorerAddressLink returns url for non-devnet", () => {
     const url = getBlockExplorerAddressLink(chains.sepolia, "0xaddr");
     expect(url).toContain("0xaddr");
+  });
+
+  test("getBlockExplorerAddressLink returns local path for devnet", () => {
+    const url = getBlockExplorerAddressLink(chains.devnet, "0xaddr");
+    expect(url).toBe("/blockexplorer/address/0xaddr");
+  });
+
+  test("getBlockExplorerAddressLink returns starkscan fallback for mainnet", () => {
+    const url = getBlockExplorerAddressLink(chains.mainnet, "0xaddr");
+    expect(url).toContain("0xaddr");
+    expect(url).toContain("/contract/");
   });
 
   test("getBlockExplorerClasshashLink returns url for non-devnet", () => {
@@ -26,10 +50,46 @@ describe("network utils", () => {
     expect(url).toContain("0xclass");
   });
 
+  test("getBlockExplorerClasshashLink returns local path for devnet", () => {
+    const url = getBlockExplorerClasshashLink(chains.devnet, "0xclass");
+    expect(url).toBe("/blockexplorer/class/0xclass");
+  });
+
+  test("getBlockExplorerClasshashLink returns starkscan fallback for mainnet", () => {
+    const url = getBlockExplorerClasshashLink(chains.mainnet, "0xclass");
+    expect(url).toContain("0xclass");
+    expect(url).toContain("/class/");
+  });
+
   test("getBlockExplorerLink returns expected base", () => {
-    expect(getBlockExplorerLink(chains.mainnet)).toBe("https://starkscan.co/");
+    expect(getBlockExplorerLink(chains.mainnet)).toBe("https://voyager.online/");
     expect(getBlockExplorerLink(chains.sepolia)).toBe(
-      "https://sepolia.starkscan.co/",
+      "https://sepolia.voyager.online/",
     );
+  });
+
+  test("getBlockExplorerLink returns sepolia url for devnet", () => {
+    expect(getBlockExplorerLink(chains.devnet)).toBe(
+      "https://sepolia.voyager.online/",
+    );
+  });
+
+  test("getTargetNetworks returns array of networks", () => {
+    const networks = getTargetNetworks();
+    expect(Array.isArray(networks)).toBe(true);
+    expect(networks.length).toBeGreaterThan(0);
+    expect(networks[0]).toHaveProperty("network");
+  });
+
+  test("NETWORKS_EXTRA_DATA has entries for known chains", () => {
+    expect(NETWORKS_EXTRA_DATA[chains.devnet.network]).toBeDefined();
+    expect(NETWORKS_EXTRA_DATA[chains.mainnet.network]).toBeDefined();
+    expect(NETWORKS_EXTRA_DATA[chains.sepolia.network]).toBeDefined();
+  });
+
+  test("NETWORKS_EXTRA_DATA color values are correct types", () => {
+    expect(typeof NETWORKS_EXTRA_DATA[chains.devnet.network].color).toBe("string");
+    expect(typeof NETWORKS_EXTRA_DATA[chains.mainnet.network].color).toBe("string");
+    expect(Array.isArray(NETWORKS_EXTRA_DATA[chains.sepolia.network].color)).toBe(true);
   });
 });

--- a/packages/create-stark-rn/template/rn/utils/scaffold-stark/__tests__/toast.test.ts
+++ b/packages/create-stark-rn/template/rn/utils/scaffold-stark/__tests__/toast.test.ts
@@ -1,6 +1,9 @@
 import { appToast } from "@/utils/scaffold-stark/toast";
 
-jest.mock("react-native", () => ({ Linking: { openURL: jest.fn() } }));
+const mockOpenURL = jest.fn();
+jest.mock("react-native", () => ({
+  Linking: { openURL: (...args: any[]) => mockOpenURL(...args) },
+}));
 const mockShow = jest.fn();
 const mockHide = jest.fn();
 jest.mock("toastify-react-native", () => ({
@@ -15,6 +18,7 @@ describe("toast wrapper", () => {
   beforeEach(() => {
     mockShow.mockClear();
     mockHide.mockClear();
+    mockOpenURL.mockClear();
   });
 
   test("showPersistentInfo passes correct options", () => {
@@ -26,6 +30,28 @@ describe("toast wrapper", () => {
         text2: "subtitle",
         position: "center",
         autoHide: false,
+      }),
+    );
+  });
+
+  test("showPersistentInfo uses default position", () => {
+    appToast.showPersistentInfo("title");
+    expect(mockShow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "info",
+        text1: "title",
+        text2: undefined,
+        position: "top",
+        autoHide: false,
+      }),
+    );
+  });
+
+  test("showPersistentInfo passes useModal option", () => {
+    appToast.showPersistentInfo("title", undefined, { useModal: true });
+    expect(mockShow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        useModal: true,
       }),
     );
   });
@@ -42,6 +68,32 @@ describe("toast wrapper", () => {
     );
   });
 
+  test("showWaiting without url has no text2", () => {
+    appToast.showWaiting("waiting");
+    expect(mockShow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "info",
+        text1: "waiting",
+        text2: undefined,
+        autoHide: false,
+      }),
+    );
+  });
+
+  test("showWaiting onPress opens url when provided", () => {
+    appToast.showWaiting("waiting", "https://explorer/tx");
+    const call = mockShow.mock.calls[0][0];
+    call.onPress();
+    expect(mockOpenURL).toHaveBeenCalledWith("https://explorer/tx");
+  });
+
+  test("showWaiting onPress does nothing without url", () => {
+    appToast.showWaiting("waiting");
+    const call = mockShow.mock.calls[0][0];
+    call.onPress();
+    expect(mockOpenURL).not.toHaveBeenCalled();
+  });
+
   test("showSuccess includes explorer hint when url provided", () => {
     appToast.showSuccess("success", "https://explorer/tx");
     expect(mockShow).toHaveBeenCalledWith(
@@ -50,6 +102,31 @@ describe("toast wrapper", () => {
         text2: "Tap to view in explorer",
       }),
     );
+  });
+
+  test("showSuccess without url has no text2", () => {
+    appToast.showSuccess("success");
+    expect(mockShow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "success",
+        text1: "success",
+        text2: undefined,
+      }),
+    );
+  });
+
+  test("showSuccess onPress opens url when provided", () => {
+    appToast.showSuccess("success", "https://explorer/tx");
+    const call = mockShow.mock.calls[0][0];
+    call.onPress();
+    expect(mockOpenURL).toHaveBeenCalledWith("https://explorer/tx");
+  });
+
+  test("showSuccess onPress does nothing without url", () => {
+    appToast.showSuccess("success");
+    const call = mockShow.mock.calls[0][0];
+    call.onPress();
+    expect(mockOpenURL).not.toHaveBeenCalled();
   });
 
   test("showError calls error", () => {

--- a/packages/create-stark-rn/template/rn/utils/scaffold-stark/common.ts
+++ b/packages/create-stark-rn/template/rn/utils/scaffold-stark/common.ts
@@ -1,6 +1,6 @@
 // To be used in JSON.stringify when a field might be bigint
 // https://wagmi.sh/react/faq#bigint-serialization
-import { Address } from "@starknet-react/chains";
+import { Address } from "@starknet-start/chains";
 
 export const replacer = (_key: string, value: unknown) => {
   if (typeof value === "bigint") return value.toString();

--- a/packages/create-stark-rn/template/rn/utils/scaffold-stark/contract.ts
+++ b/packages/create-stark-rn/template/rn/utils/scaffold-stark/contract.ts
@@ -17,11 +17,11 @@ import {
   isCairoU256,
   parseGenericType,
 } from "@/utils/scaffold-stark/typeValidations";
-import { Address } from "@starknet-react/chains";
+import { Address } from "@starknet-start/chains";
 import {
   UseReadContractProps,
   UseSendTransactionProps,
-} from "@starknet-react/core";
+} from "@starknet-start/react";
 import type {
   Abi,
   ExtractAbiEventNames,

--- a/packages/create-stark-rn/template/rn/utils/scaffold-stark/network.ts
+++ b/packages/create-stark-rn/template/rn/utils/scaffold-stark/network.ts
@@ -1,5 +1,5 @@
 import scaffoldConfig from "@/scaffold.config";
-import { Chain, devnet, mainnet, sepolia } from "@starknet-react/chains";
+import { Chain, devnet, mainnet, sepolia } from "@starknet-start/chains";
 export const chains = {
   devnet,
   sepolia,
@@ -43,11 +43,10 @@ export function getBlockExplorerTxLink(network: string, txnHash: string) {
   }
 
   const targetChain = targetChainArr[0] as keyof typeof chains;
-  // @ts-expect-error : ignoring error since `blockExplorers` key may or may not be present on some chains
-  const blockExplorerBaseURL = chains[targetChain].explorers?.starkscan[0];
+  const blockExplorerBaseURL = (chains[targetChain] as Chain).explorers?.voyager?.[0];
 
   if (!blockExplorerBaseURL) {
-    return `https://starkscan.co/tx/${txnHash}`;
+    return `https://voyager.online/tx/${txnHash}`;
   }
 
   return `${blockExplorerBaseURL}/tx/${txnHash}`;
@@ -55,16 +54,16 @@ export function getBlockExplorerTxLink(network: string, txnHash: string) {
 
 /**
  * Gives the block explorer URL for a given address.
- * Defaults to Starkscan if no block explorer is configured for the network.
+ * Defaults to Voyager if no block explorer is configured for the network.
  */
 export function getBlockExplorerAddressLink(network: Chain, address: string) {
-  const blockExplorerBaseURL = network.explorers?.starkscan[0];
+  const blockExplorerBaseURL = network.explorers?.voyager?.[0];
   if (network.network === chains.devnet.network) {
     return `/blockexplorer/address/${address}`;
   }
 
   if (!blockExplorerBaseURL) {
-    return `https://starkscan.co/contract/${address}`;
+    return `https://voyager.online/contract/${address}`;
   }
 
   return `${blockExplorerBaseURL}/contract/${address}`;
@@ -72,16 +71,16 @@ export function getBlockExplorerAddressLink(network: Chain, address: string) {
 
 /**
  * Gives the block explorer URL for a given classhash.
- * Defaults to Starkscan if no block explorer is configured for the network.
+ * Defaults to Voyager if no block explorer is configured for the network.
  */
 export function getBlockExplorerClasshashLink(network: Chain, address: string) {
-  const blockExplorerBaseURL = network.explorers?.starkscan[0];
+  const blockExplorerBaseURL = network.explorers?.voyager?.[0];
   if (network.network === chains.devnet.network) {
     return `/blockexplorer/class/${address}`;
   }
 
   if (!blockExplorerBaseURL) {
-    return `https://starkscan.co/class/${address}`;
+    return `https://voyager.online/class/${address}`;
   }
 
   return `${blockExplorerBaseURL}/class/${address}`;
@@ -90,11 +89,11 @@ export function getBlockExplorerClasshashLink(network: Chain, address: string) {
 export function getBlockExplorerLink(network: Chain) {
   switch (network) {
     case chains.mainnet:
-      return "https://starkscan.co/";
+      return "https://voyager.online/";
     default:
     case chains.devnet:
     case chains.sepolia:
-      return "https://sepolia.starkscan.co/";
+      return "https://sepolia.voyager.online/";
   }
 }
 


### PR DESCRIPTION
## Summary

Brings `packages/create-stark-rn/template/rn/*` up to parity with the now-bumped `packages/rn/*` workspace. Without this, anyone running `create-stark-rn` today scaffolds a project that **won't typecheck** because the template still pointed at legacy `@starknet-react/core` and broken Contract patterns.

Surfaced and required as a follow-up to PR #43.

## Commits (3 atomic on `ac2e1b1`)

| Commit | What |
|---|---|
| (a) | Migrate imports `@starknet-react/*` → `@starknet-start/*`; replace `InjectedConnector` with `WalletWithStarknetFeatures`; fix `Contract` ctor 3-arg → options-bag |
| (b) | Bump template `package.json` deps to scaffold-stark-rn parity (`@starknet-start/*` 1.0.7-1.0.8); declare `toastify-react-native` + `react-native-vector-icons` directly |
| (c) | Regenerate template lockfile |

## Why API migration and import migration in ONE commit

`voyager` moved from `@starknet-react/core` to `@starknet-start/explorers` (different package), and `InjectedConnector` was replaced wholesale by `WalletWithStarknetFeatures` (different concept). An import-only intermediate commit would be a broken bisect point — bundled them and documented in commit (a)'s body.

## Intentional divergences from `packages/rn/*` (with reasons)

1. **`useScaffoldContract.ts` ctor → options-bag form.** `develop`'s rn workspace still has the broken 3-arg `new Contract(abi, address, provider)` form (PR #43 fixes it). Mirroring rn verbatim would re-introduce the bug; applied PR #43's fix on top.
2. **`tsconfig.json` `skipLibCheck: true` + federation runtime patch** — same rationale as PR #43, required for the template to actually typecheck.
3. **Kept local `@/utils/scaffold-stark/ethUnits`** in 5 files instead of importing `viem` (which the rn workspace does). The template already solves the round-2 "viem phantom dep" finding with a local `ethUnits.ts`; switching to `viem` imports would have been a regression.
4. **Declared `toastify-react-native` + `react-native-vector-icons` in template's own `package.json`.** rn workspace has them at the monorepo root only; a standalone scaffolded project has no root to inherit from. Fixes the round-2 "misplaced root deps" finding for the template.
5. **`package.json` scripts kept minimal** (start/android/ios/web/lint/test/test:watch/format/postinstall). Dropped eas/maestro/coverage:* scripts — those are rn-monorepo concerns. Also removed `jest.coverageThreshold` and `setupFiles` (the 85%/70% threshold gates the rn workspace, not a fresh scaffold).

## Supply-chain gate

- ✅ Lockfile scan: zero matches for `@tanstack/(router|db|pacer|devtools|config)`, `@squawk`, `@uipath`, `@tallyui`, `@mistralai`, `@bitwarden/cli`, `plain-crypto-js`, axios 1.14.1 / 0.30.4
- ✅ `yarn npm audit`: no new HIGH/CRITICAL vs develop
- ✅ `@starknet-start/*` 1.0.7/1.0.8 published 2026-01-12 — predates every 2026 incident

## Test plan

- [x] Scaffolded a temp project from the updated template — `npx tsc --noEmit` returns 0 production-source errors, 0 node_modules errors (skipLibCheck working); 25 errors only in `__tests__/*.ts` — same test-typing bugs that exist in develop's rn workspace, not regressions
- [x] `app/_layout.tsx Cannot find module 'toastify-react-native'` error disappeared after explicit dep declaration
- [ ] Reviewer: run `npx create-stark-rn` and verify a fresh scaffold produces a project that boots Metro

## Dependency note for reviewer

This PR depends on the same migration fixes that landed in PR #43 (Contract ctor, skipLibCheck, federation patch). The template applies them locally on top, so this PR can merge independently — but if PR #43 is reverted, this PR's rationale partially evaporates.