### PR TITLE
Sync conflict from develop@8ff2993

### DIFF
--- a/packages/snfoundry/contracts/Scarb.toml
+++ b/packages/snfoundry/contracts/Scarb.toml
@@ -13,6 +13,7 @@ openzeppelin_interfaces = ">=2.0.0"
 
 [dev-dependencies]
 openzeppelin_utils = ">=2.0.0"
+# openzeppelin_testing = "6.1.0"
 snforge_std = "0.60.0"
 
 [[target.starknet-contract]]
@@ -33,3 +34,4 @@ block_id.tag = "latest"
 
 [tool]
 panic-backtrace = true
+

--- a/packages/snfoundry/contracts/src/your_contract.cairo
+++ b/packages/snfoundry/contracts/src/your_contract.cairo
@@ -105,7 +105,7 @@ pub mod YourContract {
         }
         fn withdraw(ref self: ContractState) {
             self.ownable.assert_only_owner();
-            let strk_contract_address: ContractAddress = FELT_STRK_CONTRACT.try_into().unwrap();
+            let strk_contract_address = FELT_STRK_CONTRACT.try_into().unwrap();
             let strk_dispatcher = IERC20Dispatcher { contract_address: strk_contract_address };
             let balance = strk_dispatcher.balance_of(get_contract_address());
             strk_dispatcher.transfer(self.ownable.owner(), balance);

--- a/packages/snfoundry/package.json
+++ b/packages/snfoundry/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "@ss-rn/snfoundry",
+  "name": "@ss-2/snfoundry",
   "version": "0.0.1",
   "scripts": {
     "chain": "starknet-devnet --seed 0",
     "deploy": "ts-node scripts-ts/helpers/deploy-wrapper.ts",
     "deploy:clear": "cd deployments && node clear.mjs $* && cd .. && ts-node scripts-ts/helpers/deploy-wrapper.ts $*",
-    "deploy:no-reset": "yarn workspace @ss-rn/snfoundry deploy --no-reset",
+    "deploy:no-reset": "yarn workspace @ss-2/snfoundry deploy --no-reset",
     "test": "cd contracts && snforge test",
     "test-eslint": "node eslint-contract-name/eslint-plugin-contract-names.test.js",
     "compile": "ts-node scripts-ts/compile.ts",

--- a/packages/snfoundry/scripts-ts/helpers/log.ts
+++ b/packages/snfoundry/scripts-ts/helpers/log.ts
@@ -17,9 +17,9 @@ export const logDeploymentSummary = ({
 }) => {
   let baseUrl: any;
   if (network === "sepolia") {
-    baseUrl = `https://sepolia.starkscan.co`;
+    baseUrl = `https://sepolia.voyager.online`;
   } else if (network === "mainnet") {
-    baseUrl = `https://starkscan.co`;
+    baseUrl = `https://voyager.online`;
   } else {
     console.error(red(`Unsupported network: ${network}`));
     return;

--- a/packages/snfoundry/scripts-ts/helpers/parse-deployments.ts
+++ b/packages/snfoundry/scripts-ts/helpers/parse-deployments.ts
@@ -3,7 +3,7 @@ import path from "path";
 import prettier from "prettier";
 import { Abi, CompiledSierra } from "starknet";
 
-const TARGET_DIR = path.join(__dirname, "../../../rn/contracts");
+const TARGET_DIR = path.join(__dirname, "../../../nextjs/contracts");
 const deploymentsDir = path.join(__dirname, "../../deployments");
 const files = fs.readdirSync(deploymentsDir);
 

--- a/packages/snfoundry/scripts-ts/verify-contracts.ts
+++ b/packages/snfoundry/scripts-ts/verify-contracts.ts
@@ -2,7 +2,7 @@ import path from "path";
 import { execSync } from "child_process";
 import yargs from "yargs";
 import { green, red, yellow } from "./helpers/colorize-log";
-import deployedContracts from "../../rn/contracts/deployedContracts";
+import deployedContracts from "../../nextjs/contracts/deployedContracts";
 
 function main() {
   // Parse command line arguments

--- a/packages/snfoundry/tsconfig.json
+++ b/packages/snfoundry/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "module": "CommonJS",
     "esModuleInterop": true,
+    "skipLibCheck": true,
     "target": "ES2020",
     "moduleResolution": "node",
     "outDir": "./dist",


### PR DESCRIPTION
## Automated sync conflict from scaffold-stark-2

The sync workflow could not apply `./.github/rn.patch` cleanly onto `develop`. Partial changes (rsync of `packages/snfoundry/` and `.tool-versions`) have been committed to this branch so the patch failure can be inspected against the latest tree.

| Field | Value |
| --- | --- |
| Source ref | `develop` |
| Source SHA | `8ff2993525c3d8104887b605f77907250d8ba4aa` |
| Trigger | `workflow_dispatch` |
| Failing step | `git apply -p1 ./.github/rn.patch` |

### Patch log

```
error: patch failed: packages/snfoundry/contracts/Scarb.toml:28
error: packages/snfoundry/contracts/Scarb.toml: patch does not apply
```

### Manual resolution

1. `git fetch origin && git checkout sync/from-develop-8ff2993`
2. Re-run `git apply -p1 ./.github/rn.patch` and inspect rejected hunks (`*.rej` files).
3. Resolve conflicts, amend the sync commit, force-push.
4. When CI is green, merge this PR into `develop`.
