### PR TITLE
fix(ci): add T5 viem→ethUnits curation rewrite + harden template-sync transforms

### DIFF
--- a/.github/workflows/sync-template-from-packages.yml
+++ b/.github/workflows/sync-template-from-packages.yml
@@ -218,6 +218,38 @@ jobs:
             fi
           fi
 
+          # T5 — rn ethUnits curation: source imports formatEther/parseEther/
+          # formatUnits from "viem", but viem is DELIBERATELY undeclared in both
+          # rn/package.json files (Task-1 classified rn ethUnits usage as
+          # INTENTIONAL template curation). The curated template re-points
+          # exactly these four files at the template-only shim
+          # @/utils/scaffold-stark/ethUnits. rsync has no transform for this, so
+          # without T5 the sync would ship a template importing an undeclared
+          # package (broken generated-project install). Per-file grep-gated,
+          # exactly like T1–T4: a missing file or vanished 'from "viem"' sentinel
+          # (upstream refactor) surfaces as a CONFLICT PR, never a silent break.
+          if [ "$CONFLICT" != true ]; then
+            for rel in \
+              app/_components/debug/contract/utilsDisplay.tsx \
+              components/scaffold-stark/utilsDisplay.tsx \
+              components/scaffold-stark/Input/IntegerInput.tsx \
+              hooks/scaffold-stark/useScaffoldStrkBalance.ts; do
+              f="$RN_DST/$rel"
+              if [ ! -f "$f" ]; then
+                CONFLICT=true; REASON="$f missing after rsync — ethUnits-curated file removed/renamed upstream; review T5."
+                break
+              elif ! grep -q 'from "viem"' "$f"; then
+                CONFLICT=true; REASON="'from \"viem\"' not found in $f — upstream changed the ethUnits-curated import; review T5."
+                break
+              fi
+              sed -i 's|from "viem"|from "@/utils/scaffold-stark/ethUnits"|' "$f"
+              if grep -q 'from "viem"' "$f" || ! grep -q 'from "@/utils/scaffold-stark/ethUnits"' "$f"; then
+                CONFLICT=true; REASON="T5 post-check failed — viem import not re-pointed to ethUnits shim in $f."
+                break
+              fi
+            done
+          fi
+
           if [ "$CONFLICT" = true ]; then
             echo "::warning::template-sync rewrite sanity check failed; staging partial sync for manual review."
             echo "$REASON"


### PR DESCRIPTION
## Summary

`sync-template-from-packages.yml` (#48) rsyncs `packages/rn` + `packages/snfoundry` into `packages/create-stark-rn/template/` and applies four gated rewrites (T1–T4). Local reproduction of that pipeline against the now-in-parity `develop` (HEAD `1331978`, includes #47 `de60bc1` + #48 `1331978`) showed it is **not** a clean no-op — 7 files diverge. This PR classifies all 7 with evidence and fixes the **one true regression** by adding **T5**.

**Workflow file only. Source packages are not touched.**

## Per-item classification (7 divergences)

| # | File(s) | Classification | Evidence | Action |
|---|---|---|---|---|
| 1 | `template/rn/app/_components/debug/contract/utilsDisplay.tsx`, `template/rn/components/scaffold-stark/utilsDisplay.tsx`, `template/rn/components/scaffold-stark/Input/IntegerInput.tsx`, `template/rn/hooks/scaffold-stark/useScaffoldStrkBalance.ts` | **TRUE DEFECT — broken-template regression** | Source imports `formatEther`/`parseEther`/`formatUnits` from `"viem"`; `viem` is **undeclared in both `rn/package.json` files**. #47 classified rn ethUnits usage as INTENTIONAL template curation (re-pointed to the template-only shim `@/utils/scaffold-stark/ethUnits`). No rsync/T1–T4 transform re-applies this → first sync would ship a template importing an undeclared package. | **Fixed**: added grep-gated **T5** |
| 2 | `template/rn/package.json` (drops `react-native-vector-icons@^10.3.0`) | Documented intended one-time reconciliation — **not** a regression | 0 import sites in source or template; both use `@expo/vector-icons`. #47 body: *"…dead cruft … sync workflow's deterministic package.json transform will reconcile it naturally."* #48 body: *"…the intended natural reconciliation noted in the parity-fix PR."* Drops an unused dep (not an undeclared/build-breaking add). | Accept self-heal; documented. No transform. |
| 3 | `template/snfoundry/scripts-ts/helpers/log.ts` (`starkscan.co` → `voyager.online`) | MISSED-stale → self-heal toward source — **not** a regression | Template value frozen at `0b1376d` ("feat: add create-stark-rn CLI scaffolder") initial-scaffolder snapshot, never a deliberate later curation. Pure console explorer-link URL — no build/functional/generated-project impact. Source is current upstream choice. | Accept self-heal; documented. No transform. |
| 4 | `template/snfoundry/tsconfig.json` (adds `"skipLibCheck": true`) | MISSED-stale → self-heal toward source — **not** a regression | `skipLibCheck:true` only *relaxes* type-checking (skips `.d.ts` checks) — cannot break a build; beneficial for a standalone generated project with many third-party deps. Template omission is stale-scaffolder, not an intentional stricter-than-source choice. | Accept self-heal; documented. No transform. |

## The fix — T5 (grep-gated, mirrors T1–T4)

Post-rsync, for exactly the four ethUnits-curated files, rewrite `from "viem"` → `from "@/utils/scaffold-stark/ethUnits"`. Pre-gate: file exists **and** contains `from "viem"`. Post-gate: no residual `from "viem"` **and** shim import present. Any failure (upstream removed/renamed the import) sets `CONFLICT=true` → review PR, never a silent broken sync — identical safety contract to T1–T4. The shim exports all three used functions (`formatEther`, `parseEther`, `formatUnits`).

## Re-verification (local pipeline repro vs committed `develop` template)

| | Before T5 | After T5 |
|---|---|---|
| Files diverging | 7 | **3** |
| 4 ethUnits files | revert to `viem` (broken) | **byte-identical to committed template** |
| `from "viem"` in repro `template/rn` | present | **zero** |
| `CONFLICT` | false | false (T5 gates pass) |
| Remaining diffs | mixed regression + self-heals | **strictly the 3 documented intended one-time reconciliations** (items 2–4) |

No undeclared-dep or build-breaking change remains. **PASS** per the acceptance bar: viem→ethUnits regression eliminated; diffs limited to documented intended self-heals.

## Follow-up (not actioned here — workflow-only PR)

Items 2–4 are intended one-time self-heals on the **first** real workflow run (they converge the stale template to source and stay converged). No source-package change is required for correctness. Optional future cleanup, if desired separately: remove the dead `react-native-vector-icons` dep from `template/rn/package.json` directly so the first sync diff is even smaller. Not required for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
