### PR TITLE
fix: add explicit GITHUB_TOKEN permissions to template-sync workflow

### DIFF
--- a/.github/workflows/sync-template-from-packages.yml
+++ b/.github/workflows/sync-template-from-packages.yml
@@ -43,6 +43,9 @@ on:
       # is NOT in this filter, so the workflow cannot retrigger itself.
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 concurrency:
   group: sync-template-from-packages
   cancel-in-progress: false


### PR DESCRIPTION
## What

Adds an explicit `permissions: contents: read` block to `.github/workflows/sync-template-from-packages.yml`.

## Why

CodeQL flagged 2 medium-severity alerts on this file (added in #48) — the `check_commit` and `sync-template` jobs had no explicit `permissions` block. All write operations already use `ORG_GITHUB_TOKEN` (PAT), so the default `GITHUB_TOKEN` only needs read access.