### PR TITLE
ci: auto-publish create-stark-rn on version bump (reusable publish workflow)

### DIFF
--- a/.github/workflows/npm-publish-cli.yml
+++ b/.github/workflows/npm-publish-cli.yml
@@ -7,6 +7,25 @@ on:
         description: "Version to publish (e.g. 1.0.0). Leave empty to use version from package.json."
         required: false
         type: string
+      ref:
+        description: "Git ref to check out and publish from. Leave empty for the triggering branch."
+        required: false
+        type: string
+      dry_run:
+        description: "Dry run (skip actual publish)"
+        required: false
+        default: false
+        type: boolean
+  workflow_call:
+    inputs:
+      version:
+        description: "Version to publish (e.g. 1.0.0). Leave empty to use version from package.json."
+        required: false
+        type: string
+      ref:
+        description: "Git ref to check out and publish from. Leave empty for the triggering branch."
+        required: false
+        type: string
       dry_run:
         description: "Dry run (skip actual publish)"
         required: false
@@ -27,6 +46,20 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          # When called from version-bump, the caller passes ref: main so this
+          # checks out the POST-bump tree (the chore(release): commit) rather
+          # than the pre-bump SHA that triggered the caller workflow.
+          ref: ${{ inputs.ref || github.ref_name }}
+
+      - name: Normalize flags
+        id: flags
+        run: |
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            echo "dry_run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "dry_run=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Sync template from main rn app
         run: |
@@ -53,9 +86,9 @@ jobs:
 
       - name: Set create-stark-rn version
         run: |
-          if [ "${{ github.event.inputs.version }}" != "" ]; then
-            VERSION="${{ github.event.inputs.version }}"
-            echo "Using manual version from workflow input: $VERSION"
+          if [ -n "${{ inputs.version }}" ]; then
+            VERSION="${{ inputs.version }}"
+            echo "Using version from workflow input: $VERSION"
           else
             VERSION=$(node -pe "require('../../package.json').version")
             echo "Using scaffold-stark-rn version from root package.json: $VERSION"
@@ -66,13 +99,13 @@ jobs:
         run: npm pack --dry-run
 
       - name: Publish to npm
-        if: ${{ github.event.inputs.dry_run != 'true' }}
+        if: steps.flags.outputs.dry_run == 'false'
         run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Dry run publish
-        if: ${{ github.event.inputs.dry_run == 'true' }}
+        if: steps.flags.outputs.dry_run == 'true'
         run: npm publish --access public --dry-run
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -31,6 +31,9 @@ jobs:
     permissions:
       contents: write
 
+    outputs:
+      new_version: ${{ steps.version.outputs.new }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -128,3 +131,19 @@ jobs:
           git commit -m "chore(release): $VERSION"
           git tag "v$VERSION"
           git push origin main --follow-tags
+
+  publish:
+    name: Publish create-stark-rn
+    needs: bump
+    # bump has an `if:` guard — if it is skipped (e.g. a chore(release): commit),
+    # `needs: bump` makes this job skip too, so no double publish / loop.
+    uses: ./.github/workflows/npm-publish-cli.yml
+    secrets: inherit
+    with:
+      # Publish exactly the version the bump job just computed and pushed.
+      version: ${{ needs.bump.outputs.new_version }}
+      # Operate on the POST-bump tree: bump has already pushed the
+      # `chore(release):` commit to main by the time this job starts
+      # (guaranteed by `needs: bump`), so origin/main is the bumped tree.
+      ref: main
+      dry_run: false


### PR DESCRIPTION
## Summary

Wires automatic npm publish into the version-bump pipeline so `scaffold-stark-rn` behaves like `scaffold-stark-2`: a version bump and the `create-stark-rn` npm publish now happen in **one flow**. The standalone manual publish button is fully preserved as a fallback.

**Before:** `version-bump.yml` (push to `main`) bumped versions, committed `chore(release): X`, tagged, pushed — and stopped. `npm-publish-cli.yml` was `workflow_dispatch`-only; nothing triggered it automatically, so `create-stark-rn` only reached npm when a human clicked Run.

**After:** the bump job's computed version feeds a new `publish` job that calls the (now reusable) publish workflow automatically.

## Approach

1. **`npm-publish-cli.yml` → reusable workflow.** Added a `workflow_call:` trigger mirroring the existing `workflow_dispatch:` inputs (`version`, `dry_run`) plus a new `ref` input. Switched from `github.event.inputs.*` to the unified `inputs.*` context (valid for both `workflow_dispatch` and `workflow_call`). `dry_run` is now normalized through a shell step to dodge GitHub's string-vs-boolean loose-equality pitfall (`'true' == true` is *false* in Actions expressions).
2. **`version-bump.yml` → wire publish.** The `bump` job now exposes `new_version` as an output. A new `publish` job (`needs: bump`) calls `./.github/workflows/npm-publish-cli.yml` with `secrets: inherit`, passing `version: <new_version>`, `ref: main`, `dry_run: false`.

## Timing-hazard trace (the important part)

The hazard: in a single workflow run, `actions/checkout` defaults to the **SHA that triggered the run** — the commit *before* the `chore(release):` bump. A naive publish job would rsync the template from the **pre-bump** `packages/rn/` and publish stale source under the new version number.

**How this PR avoids it — full trace** (developer merges `feat: …` to `main`, SHA `A`):

| Step | What happens |
|---|---|
| `bump` runs | `if` guard: `A`'s msg is `feat: …` → not `chore(release):` → runs. Computes e.g. `1.0.5 → 1.1.0`. Commits `chore(release): 1.1.0` = SHA `B`, tags, `git push origin main` → **origin/main tip = B**. Job output `new_version=1.1.0`. |
| `publish` runs | `needs: bump` ⇒ starts only **after** bump pushed `B`. Calls reusable workflow with `ref: main`. |
| reusable checkout | `ref: ${{ inputs.ref \|\| github.ref_name }}` → `main` → checks out **origin/main = B (post-bump tree)**. `packages/rn/` is the bumped source. ✅ |
| version set | `inputs.version = 1.1.0` → `npm version 1.1.0`. **Published version == bumped version.** ✅ |
| publish | `dry_run` normalized to `false` → `npm publish --access public` with `NPM_TOKEN` (via `secrets: inherit`). |
| bump's own push re-triggers workflow | `B`'s msg **is** `chore(release):` → `bump` skipped → `needs: bump` ⇒ `publish` skipped. **No double publish, no loop.** ✅ |

`ref: main` (not the `vX` tag) is a deliberate choice — see "Pre-existing issue noted" below.

## Preserved behavior

- ✅ Loop guard intact (`chore(release):` push skips both `bump` and `publish`).
- ✅ `dry_run` end-to-end (and now type-safe across both triggers).
- ✅ `NPM_TOKEN` reaches the publish job via `secrets: inherit`.
- ✅ Manual **"Publish create-stark-rn to npm"** `workflow_dispatch` still works standalone: empty `ref` → triggering branch; empty `version` → root `package.json` (identical to prior behavior).
- ✅ Manual `workflow_dispatch` of version-bump now also bump+publishes (matches the requested scaffold-stark-2 behavior).

## Verification

- `actionlint` on both workflows: **clean, no findings** (validates `inputs` context vs triggers, local reusable `uses:`, `secrets: inherit`).
- `python3 -c "yaml.safe_load(...)"` both files: parse OK.
- Static trigger/checkout/version trace above (CI-side dispatch testing is impossible pre-merge: `gh workflow run` / `disable` return 404 until the workflow exists on the default branch — known repo constraint).

## ⚠️ Activation note

`version-bump.yml` only fires on **push to `main`**. Per repo convention this PR targets **`develop`**, so it has **no effect until `develop` is merged to `main`**. The auto-publish path goes live on the first non-`chore(release):` push to `main` after that merge.

## Pre-existing issue noted (not fixed here — out of scope)

`version-bump.yml` creates a **lightweight** tag (`git tag "v$VERSION"`) but pushes with `git push origin main --follow-tags`, which only pushes **annotated** tags — so `vX` tags likely never reach origin today. This PR intentionally publishes from `ref: main` rather than `ref: vX` so it is **not** affected by this. Flagging for a separate fix if tag-on-origin is desired.

## Files changed

- `.github/workflows/npm-publish-cli.yml` — `+38 / -5` (reusable via `workflow_call`, unified `inputs`, normalized `dry_run`, explicit checkout `ref`).
- `.github/workflows/version-bump.yml` — `+19 / -0` (bump job output + new `publish` job).
