### PR TITLE
Template sync conflict @ 369d5be

### DIFF
--- a/packages/create-stark-rn/template/rn/app/_components/debug/contract/utilsDisplay.tsx
+++ b/packages/create-stark-rn/template/rn/app/_components/debug/contract/utilsDisplay.tsx
@@ -9,7 +9,7 @@ import {
 } from "@/utils/scaffold-stark/typeValidations";
 import { Abi } from "abi-wan-kanabi";
 import { getChecksumAddress, Uint256 } from "starknet";
-import { formatEther } from "@/utils/scaffold-stark/ethUnits";
+import { formatEther } from "viem";
 
 type DisplayContent = Uint256 | string | bigint | boolean | Object | unknown;
 

--- a/packages/create-stark-rn/template/rn/components/scaffold-stark/Input/IntegerInput.tsx
+++ b/packages/create-stark-rn/template/rn/components/scaffold-stark/Input/IntegerInput.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { Text, TouchableOpacity } from "react-native";
-import { parseEther } from "@/utils/scaffold-stark/ethUnits";
+import { parseEther } from "viem";
 import { InputBase } from "./InputBase";
 import { CommonInputProps, isValidInteger } from "./utils";
 

--- a/packages/create-stark-rn/template/rn/components/scaffold-stark/utilsDisplay.tsx
+++ b/packages/create-stark-rn/template/rn/components/scaffold-stark/utilsDisplay.tsx
@@ -8,7 +8,7 @@ import {
   parseGenericType,
 } from "@/utils/scaffold-stark/typeValidations";
 import { Abi } from "abi-wan-kanabi";
-import { formatEther } from "@/utils/scaffold-stark/ethUnits";
+import { formatEther } from "viem";
 import { getChecksumAddress, Uint256 } from "starknet";
 
 type DisplayContent = Uint256 | string | bigint | boolean | Object | unknown;

--- a/packages/create-stark-rn/template/rn/hooks/scaffold-stark/useScaffoldStrkBalance.ts
+++ b/packages/create-stark-rn/template/rn/hooks/scaffold-stark/useScaffoldStrkBalance.ts
@@ -2,7 +2,7 @@ import { Address } from "@starknet-start/chains";
 import { useReadContract } from "@starknet-start/react";
 import { Abi } from "abi-wan-kanabi";
 import { BlockNumber } from "starknet";
-import { formatUnits } from "@/utils/scaffold-stark/ethUnits";
+import { formatUnits } from "viem";
 import { useDeployedContractInfo } from "./useDeployedContractInfo";
 
 type UseScaffoldStrkBalanceProps = {

--- a/packages/create-stark-rn/template/snfoundry/contracts/src/lib.cairo
+++ b/packages/create-stark-rn/template/snfoundry/contracts/src/lib.cairo
@@ -1,2 +1,1 @@
 pub mod your_contract;
-

--- a/packages/create-stark-rn/template/snfoundry/package.json
+++ b/packages/create-stark-rn/template/snfoundry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ss-rn/snfoundry",
-  "version": "1.0.5",
+  "version": "0.0.1",
   "scripts": {
     "chain": "starknet-devnet --seed 0",
     "deploy": "ts-node scripts-ts/helpers/deploy-wrapper.ts",


### PR DESCRIPTION
## Automated template-sync conflict

A grep/jq sanity check failed while rewriting the rsync'd tree from `packages/rn` + `packages/snfoundry` into `packages/create-stark-rn/template/`. The partial sync (rsync + any rewrites that passed) is committed to this branch so the failure can be inspected against the latest tree.

| Field | Value |
| --- | --- |
| Source SHA | `369d5be` |
| Trigger | `push` |
| Failing rewrite | grep 'nextjs/contracts' not found in packages/create-stark-rn/template/snfoundry/scripts-ts/verify-contracts.ts — upstream may have fixed/renamed it; review T4. |

### Sanity-check reason

```
grep 'nextjs/contracts' not found in packages/create-stark-rn/template/snfoundry/scripts-ts/verify-contracts.ts — upstream may have fixed/renamed it; review T4.
```

### Manual resolution

1. `git fetch origin && git checkout sync/template-369d5be`
2. Inspect the failing rewrite (T1–T4) in `.github/workflows/sync-template-from-packages.yml`. If the source package legitimately renamed a sentinel (`@ss-rn/rn`, the snfoundry deploy script, the autogenerated header, or `nextjs/contracts`), update that rewrite + its grep/jq gate. Otherwise resolve manually on this branch.
3. Resolve, amend the sync commit, force-push.
4. When CI is green, merge this PR into `develop`.
