### PR TITLE
Template sync conflict @ be09428

### DIFF
--- a/packages/create-stark-rn/template/rn/app/_components/debug/contract/utilsDisplay.tsx
+++ b/packages/create-stark-rn/template/rn/app/_components/debug/contract/utilsDisplay.tsx
@@ -9,7 +9,7 @@ import {
 } from "@/utils/scaffold-stark/typeValidations";
 import { Abi } from "abi-wan-kanabi";
 import { getChecksumAddress, Uint256 } from "starknet";
-import { formatEther } from "@/utils/scaffold-stark/ethUnits";
+import { formatEther } from "viem";
 
 type DisplayContent = Uint256 | string | bigint | boolean | Object | unknown;
 

--- a/packages/create-stark-rn/template/rn/components/scaffold-stark/Input/IntegerInput.tsx
+++ b/packages/create-stark-rn/template/rn/components/scaffold-stark/Input/IntegerInput.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { Text, TouchableOpacity } from "react-native";
-import { parseEther } from "@/utils/scaffold-stark/ethUnits";
+import { parseEther } from "viem";
 import { InputBase } from "./InputBase";
 import { CommonInputProps, isValidInteger } from "./utils";
 

--- a/packages/create-stark-rn/template/rn/components/scaffold-stark/utilsDisplay.tsx
+++ b/packages/create-stark-rn/template/rn/components/scaffold-stark/utilsDisplay.tsx
@@ -8,7 +8,7 @@ import {
   parseGenericType,
 } from "@/utils/scaffold-stark/typeValidations";
 import { Abi } from "abi-wan-kanabi";
-import { formatEther } from "@/utils/scaffold-stark/ethUnits";
+import { formatEther } from "viem";
 import { getChecksumAddress, Uint256 } from "starknet";
 
 type DisplayContent = Uint256 | string | bigint | boolean | Object | unknown;

--- a/packages/create-stark-rn/template/rn/hooks/scaffold-stark/useScaffoldStrkBalance.ts
+++ b/packages/create-stark-rn/template/rn/hooks/scaffold-stark/useScaffoldStrkBalance.ts
@@ -2,7 +2,7 @@ import { Address } from "@starknet-start/chains";
 import { useReadContract } from "@starknet-start/react";
 import { Abi } from "abi-wan-kanabi";
 import { BlockNumber } from "starknet";
-import { formatUnits } from "@/utils/scaffold-stark/ethUnits";
+import { formatUnits } from "viem";
 import { useDeployedContractInfo } from "./useDeployedContractInfo";
 
 type UseScaffoldStrkBalanceProps = {

--- a/packages/create-stark-rn/template/snfoundry/contracts/Scarb.toml
+++ b/packages/create-stark-rn/template/snfoundry/contracts/Scarb.toml
@@ -9,12 +9,12 @@ edition = "2024_07"
 starknet = ">=2.18.0"
 openzeppelin_access = ">=3.0.0"
 openzeppelin_token = ">=3.0.0"
-openzeppelin_interfaces = ">=2.0.0"
+openzeppelin_interfaces = ">=2.0.0, <3.0.0"
 
 [dev-dependencies]
 openzeppelin_utils = ">=2.0.0"
 # openzeppelin_testing = "6.1.0"
-snforge_std = "0.60.0"
+snforge_std = "0.62.1"
 
 [[target.starknet-contract]]
 casm = true # taggle this to `false` to speed up compilation/script tests

--- a/packages/create-stark-rn/template/snfoundry/contracts/src/lib.cairo
+++ b/packages/create-stark-rn/template/snfoundry/contracts/src/lib.cairo
@@ -1,2 +1,1 @@
 pub mod your_contract;
-

--- a/packages/create-stark-rn/template/snfoundry/contracts/tests/test_contract.cairo
+++ b/packages/create-stark-rn/template/snfoundry/contracts/tests/test_contract.cairo
@@ -60,3 +60,33 @@ fn test_transfer() {
         ); // we transfer 500 wei
     assert(your_contract_dispatcher.greeting() == new_greeting, 'Should allow set new message');
 }
+
+#[test]
+#[fork("SEPOLIA_LATEST")]
+#[should_panic(
+    expected: ('ERC20: insufficient allowance', 'ENTRYPOINT_FAILED', 'ENTRYPOINT_FAILED'),
+)]
+fn test_set_greeting_no_allowance() {
+    let user = OWNER;
+    let your_contract_address = deploy_contract("YourContract");
+
+    let your_contract_dispatcher = IYourContractDispatcher {
+        contract_address: your_contract_address,
+    };
+
+    let new_greeting: ByteArray = "Learn Scaffold-Stark 2! :)";
+
+    cheat_caller_address(your_contract_address, user, CheatSpan::TargetCalls(1));
+    your_contract_dispatcher.set_greeting(new_greeting.clone(), Option::Some(500));
+}
+
+#[test]
+#[should_panic(expected: ('Caller is not the owner', 'ENTRYPOINT_FAILED'))]
+fn test_withdraw_not_owner() {
+    let contract_address = deploy_contract("YourContract");
+    let dispatcher = IYourContractDispatcher { contract_address };
+
+    let not_owner: ContractAddress = 0x123.try_into().unwrap();
+    cheat_caller_address(contract_address, not_owner, CheatSpan::TargetCalls(1));
+    dispatcher.withdraw();
+}

--- a/packages/create-stark-rn/template/snfoundry/package.json
+++ b/packages/create-stark-rn/template/snfoundry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ss-rn/snfoundry",
-  "version": "1.0.5",
+  "version": "0.0.1",
   "scripts": {
     "chain": "starknet-devnet --seed 0",
     "deploy": "ts-node scripts-ts/helpers/deploy-wrapper.ts",


### PR DESCRIPTION
## Automated template-sync conflict

A grep/jq sanity check failed while rewriting the rsync'd tree from `packages/rn` + `packages/snfoundry` into `packages/create-stark-rn/template/`. The partial sync (rsync + any rewrites that passed) is committed to this branch so the failure can be inspected against the latest tree.

| Field | Value |
| --- | --- |
| Source SHA | `be09428` |
| Trigger | `push` |
| Failing rewrite | grep 'nextjs/contracts' not found in packages/create-stark-rn/template/snfoundry/scripts-ts/verify-contracts.ts — upstream may have fixed/renamed it; review T4. |

### Sanity-check reason

```
grep 'nextjs/contracts' not found in packages/create-stark-rn/template/snfoundry/scripts-ts/verify-contracts.ts — upstream may have fixed/renamed it; review T4.
```

### Manual resolution

1. `git fetch origin && git checkout sync/template-be09428`
2. Inspect the failing rewrite (T1–T4) in `.github/workflows/sync-template-from-packages.yml`. If the source package legitimately renamed a sentinel (`@ss-rn/rn`, the snfoundry deploy script, the autogenerated header, or `nextjs/contracts`), update that rewrite + its grep/jq gate. Otherwise resolve manually on this branch.
3. Resolve, amend the sync commit, force-push.
4. When CI is green, merge this PR into `develop`.
